### PR TITLE
Generate code for registering the schema of the generated types

### DIFF
--- a/pkg/pipeline/crd.go
+++ b/pkg/pipeline/crd.go
@@ -81,6 +81,7 @@ func (cg *CRDGenerator) Generate(version, kind string, schema *schema.Resource) 
 			"Kind":       kind,
 		},
 		"VersionPackageAlias": file.Imports.UsePackage(groupPkgPath),
+		"APISPackageAlias":    file.Imports.UsePackage(filepath.Join(cg.RootModulePath, "apis")),
 	}
 	filePath := filepath.Join(cg.GroupDir, strings.ToLower(version), strings.ToLower(kind), "zz_types.go")
 	return errors.Wrap(file.Write(filePath, vars, os.ModePerm), "cannot write crd file")

--- a/pkg/pipeline/templates/crd_types.go.tmpl
+++ b/pkg/pipeline/templates/crd_types.go.tmpl
@@ -64,5 +64,5 @@ var (
 )
 
 func init() {
-	{{ .VersionPackageAlias }}SchemeBuilder.Register(&{{ .CRD.Kind }}{}, &{{ .CRD.Kind }}List{})
+	{{ .APISPackageAlias }}SchemaMap[{{ .VersionPackageAlias }}GroupVersion] = append({{ .APISPackageAlias }}SchemaMap[{{ .VersionPackageAlias }}GroupVersion], &{{ .CRD.Kind }}{}, &{{ .CRD.Kind }}List{})
 }

--- a/pkg/pipeline/templates/groupversion_info.go.tmpl
+++ b/pkg/pipeline/templates/groupversion_info.go.tmpl
@@ -6,7 +6,6 @@ package {{ .CRD.APIVersion }}
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.
@@ -15,13 +14,5 @@ const (
 	Version = "{{ .CRD.APIVersion }}"
 )
 
-var (
-	// GroupVersion is the API Group Version used to register the objects
-	GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
-
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
-
-	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
-)
+// GroupVersion is the API Group Version used to register the objects
+var GroupVersion = schema.GroupVersion{Group: Group, Version: Version}

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -186,7 +186,7 @@ func (g *Builder) buildSchema(sch *schema.Schema, names []string) (types.Type, e
 				elemType = obsType
 			default:
 				if paramType == nil {
-					return nil, errors.Errorf("fielement type of %s is configurable but the underlying schema does not return parameter type: %s", fieldPath(names...))
+					return nil, errors.Errorf("element type of %s is configurable but the underlying schema does not return a parameter type", fieldPath(names...))
 				}
 				elemType = paramType
 			}


### PR DESCRIPTION
With this new mechanism, we assume that there is a `var SchemaMap = map[schema.GroupVersion][]runtime.Object` in `apis` folder and all CRDs add themselves to that map instead of the group's own scheme builder. This way we don't have to have a complete list of groups anywhere that we need to iterate through. After the map is populated with `init()`s of types, we add its content to the main schema in `main.go`. This will allow us do some group/type based filtering as well, see https://github.com/crossplane/crossplane/issues/2122 for details.

See https://github.com/crossplane-contrib/provider-tf-aws/pull/6 for example usage of this feature.

Fixes https://github.com/crossplane-contrib/terrajet/issues/20