### PR TITLE
Add lifecycle.prevent_destroy meta-argument to generated HCL configurations

### DIFF
--- a/pkg/tfcli/options.go
+++ b/pkg/tfcli/options.go
@@ -73,11 +73,16 @@ func WithResourceType(resourceType string) ClientOption {
 	}
 }
 
-// WithResourceBody sets the Terraform resource body block to be used in the
-// generated  Terraform configuration
+// WithResourceBody sets the Terraform resource body parameter block to
+// be used in the generated  Terraform configuration. resourceBody
+// must be a whole JSON document containing the serialized resource
+// parameters.
 func WithResourceBody(resourceBody []byte) ClientOption {
 	return func(c *Client) {
-		c.resource.Body = resourceBody
+		// common controller serializes resource parameter block into
+		// a JSON object. However, we would like to add new fields
+		// to this JSON object and thus here we capture only the parameters.
+		c.resource.Body = resourceBody[1 : len(resourceBody)-1]
 	}
 }
 
@@ -183,6 +188,13 @@ type Resource struct {
 	LabelType string
 	LabelName string
 	Body      []byte
+	Lifecycle Lifecycle
+}
+
+// Lifecycle holds values for the Terraform HCL resource block's lifecycle options:
+// https://www.terraform.io/docs/language/meta-arguments/lifecycle.html
+type Lifecycle struct {
+	PreventDestroy bool
 }
 
 func (r Resource) validate() error {

--- a/pkg/tfcli/templates/main.tf.json.tpl
+++ b/pkg/tfcli/templates/main.tf.json.tpl
@@ -2,23 +2,30 @@
     "terraform": {
         "required_providers": {
             "tf-provider": {
-                "source":  "{{ .ProviderSource }}",
-                "version": "{{ .ProviderVersion }}"
+                "source":  "{{ .Provider.Source }}",
+                "version": "{{ .Provider.Version }}"
             }
         }
     },
 
-    {{ if .ProviderConfiguration -}}
+    {{ if .Provider.Configuration -}}
     "provider": {
         "tf-provider": [
-            {{ .ProviderConfiguration | printf "%s" }}
+            {{ .Provider.Configuration | printf "%s" }}
         ]
     },
     {{ end }}
 
     "resource": {
-        "{{ .ResourceType }}": {
-            "{{ .ResourceName }}": {{ .ResourceBody | printf "%s" }}
+        "{{ .Resource.LabelType }}": {
+            "{{ .Resource.LabelName }}": {
+                {{ .Resource.Body | printf "%s" }}
+                {{ if .Lifecycle.PreventDestroy -}}
+                    ,"lifecycle" : {
+                    "prevent_destroy": true
+                    }
+                {{ end }}
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We would like to reject any Terraform plan (excluding one for destroy) that destroys an infrastructure object.
Also fixes file permissions for generated HCL configuration files.

Please note that we have to distinguish between destroy & non-destroy operations per the behavior of the [`prevent_destroy` meta-argument](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#prevent_destroy). If we use this argument for a destroy operation, the we get the following error from Terraform CLI:
```console
╷
│ Error: Instance cannot be destroyed
│
│   on main.tf.json line 20, in resource.azurerm_virtual_network:
│   20:             "example": {
│
│ Resource azurerm_virtual_network.example has lifecycle.prevent_destroy set, but the plan calls for this resource to be destroyed. To avoid this error and continue with the plan, either disable lifecycle.prevent_destroy or reduce the scope of the plan using the -target flag.
```


Fixes #29

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested with provider-tf-azure. Validated the generated HCL configuration for destroy and other operations.

[contribution process]: https://git.io/fj2m9
