### PR TITLE
External name to parameters mapping

### DIFF
--- a/pkg/json/json.go
+++ b/pkg/json/json.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package conversion
+package json
 
 import jsoniter "github.com/json-iterator/go"
 

--- a/pkg/json/statev4.go
+++ b/pkg/json/statev4.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package conversion
+package json
 
 import (
 	"encoding/base64"
@@ -81,8 +81,8 @@ type InstanceObjectStateV4 struct {
 	CreateBeforeDestroy bool `json:"create_before_destroy,omitempty"`
 }
 
-// ParseStateV4 parses a given Terraform state as StateV4 object
-func ParseStateV4(data []byte) (*StateV4, error) {
+// UnmarshalStateV4 parses a given Terraform state as StateV4 object
+func UnmarshalStateV4(data []byte) (*StateV4, error) {
 	st := &StateV4{}
 	if err := JSParser.Unmarshal(data, st); err != nil {
 		return nil, errors.Wrap(err, errCannotParseState)
@@ -98,7 +98,7 @@ func BuildStateV4(encodedState string, attributesSensitive jsoniter.RawMessage) 
 		return nil, errors.Wrap(err, errCannotDecodeMetadata)
 	}
 
-	st, err := ParseStateV4(m)
+	st, err := UnmarshalStateV4(m)
 	if err != nil {
 		return nil, errors.Wrap(err, errCannotParseState)
 	}

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -59,7 +59,7 @@ func (cg *ControllerGenerator) Generate(c *resource.Configuration, typesPkgPath 
 		"CRD": map[string]string{
 			"Kind": c.Kind,
 		},
-		"DisableNameInitializer":            c.ExternalNamer.DisableNameInitializer,
+		"DisableNameInitializer":            c.ExternalName.DisableNameInitializer,
 		"TypePackageAlias":                  ctrlFile.Imports.UsePackage(typesPkgPath),
 		"ProviderConfigBuilderPackageAlias": ctrlFile.Imports.UsePackage(cg.ProviderConfigBuilderPath),
 	}

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/crossplane-contrib/terrajet/pkg/pipeline/templates"
+	"github.com/crossplane-contrib/terrajet/pkg/terraform/resource"
 )
 
 // NewControllerGenerator returns a new ControllerGenerator.
@@ -46,23 +47,24 @@ type ControllerGenerator struct {
 }
 
 // Generate writes controller setup functions.
-func (cg *ControllerGenerator) Generate(versionPkgPath, kind string) (pkgPath string, err error) {
-	controllerPkgPath := filepath.Join(cg.ModulePath, "internal", "controller", strings.ToLower(strings.Split(cg.Group, ".")[0]), strings.ToLower(kind))
-	ctrlFile := wrapper.NewFile(controllerPkgPath, strings.ToLower(kind), templates.ControllerTemplate,
+func (cg *ControllerGenerator) Generate(c *resource.Configuration, typesPkgPath string) (pkgPath string, err error) {
+	controllerPkgPath := filepath.Join(cg.ModulePath, "internal", "controller", strings.ToLower(strings.Split(cg.Group, ".")[0]), strings.ToLower(c.Kind))
+	ctrlFile := wrapper.NewFile(controllerPkgPath, strings.ToLower(c.Kind), templates.ControllerTemplate,
 		wrapper.WithGenStatement(GenStatement),
 		wrapper.WithHeaderPath("hack/boilerplate.go.txt"), // todo
 	)
 
 	vars := map[string]interface{}{
-		"Package": strings.ToLower(kind),
+		"Package": strings.ToLower(c.Kind),
 		"CRD": map[string]string{
-			"Kind": kind,
+			"Kind": c.Kind,
 		},
-		"TypePackageAlias":                  ctrlFile.Imports.UsePackage(versionPkgPath),
+		"DisableNameInitializer":            c.ExternalNamer.DisableNameInitializer,
+		"TypePackageAlias":                  ctrlFile.Imports.UsePackage(typesPkgPath),
 		"ProviderConfigBuilderPackageAlias": ctrlFile.Imports.UsePackage(cg.ProviderConfigBuilderPath),
 	}
 
-	filePath := filepath.Join(cg.ControllerGroupDir, strings.ToLower(kind), "zz_controller.go")
+	filePath := filepath.Join(cg.ControllerGroupDir, strings.ToLower(c.Kind), "zz_controller.go")
 	return controllerPkgPath, errors.Wrap(
 		ctrlFile.Write(filePath, vars, os.ModePerm),
 		"cannot write controller file",

--- a/pkg/pipeline/crd.go
+++ b/pkg/pipeline/crd.go
@@ -62,7 +62,7 @@ func (cg *CRDGenerator) Generate(c *resource.Configuration, sch *schema.Resource
 		wrapper.WithGenStatement(GenStatement),
 		wrapper.WithHeaderPath("hack/boilerplate.go.txt"), // todo
 	)
-	for _, omit := range c.ExternalNamer.OmittedFields {
+	for _, omit := range c.ExternalName.OmittedFields {
 		delete(sch.Schema, omit)
 	}
 	typeList, comments, err := tjtypes.NewBuilder(cg.pkg).Build(c.Kind, sch)

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -23,10 +23,13 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 	name := managed.ControllerName({{ .TypePackageAlias }}{{ .CRD.Kind }}GroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}GroupVersionKind),
-		managed.WithInitializers(),
 		managed.WithExternalConnecter(terraform.NewConnector(mgr.GetClient(), l, {{ .ProviderConfigBuilderPackageAlias }}ProviderConfigBuilder)),
 		managed.WithLogger(l.WithValues("controller", name)),
-		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
+		{{- if .DisableNameInitializer }}
+		managed.WithInitializers(),
+		{{- end}}
+		)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -38,7 +38,7 @@ func (tr *{{ .CRD.Kind }}) GetParameters() (map[string]interface{}, error) {
 	}
 	base := map[string]interface{}{}
 	{{- if .CRD.ExternalNameInjectFn }}
-	{{ .CRD.ExternalNameInjectFn }}(base, meta.GetExternalName(tr))
+	{{ .CRD.ExternalNameInjectFn }}.Configure(base, meta.GetExternalName(tr))
 	{{- end }}
 	return base, json.JSParser.Unmarshal(p, &base)
 }

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -37,7 +37,9 @@ func (tr *{{ .CRD.Kind }}) GetParameters() (map[string]interface{}, error) {
 		return nil, err
 	}
 	base := map[string]interface{}{}
+	{{- if .CRD.ExternalNameInjectFn }}
 	{{ .CRD.ExternalNameInjectFn }}(base, meta.GetExternalName(tr))
+	{{- end }}
 	return base, json.JSParser.Unmarshal(p, &base)
 }
 

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -37,8 +37,8 @@ func (tr *{{ .CRD.Kind }}) GetParameters() (map[string]interface{}, error) {
 		return nil, err
 	}
 	base := map[string]interface{}{}
-	{{- if .CRD.ExternalNameInjectFn }}
-	{{ .CRD.ExternalNameInjectFn }}.Configure(base, meta.GetExternalName(tr))
+	{{- if .CRD.ConfigureWithFn }}
+	{{ .CRD.ConfigureWithFn }}.Configure(base, meta.GetExternalName(tr))
 	{{- end }}
 	return base, json.JSParser.Unmarshal(p, &base)
 }

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -4,7 +4,11 @@
 
 package {{ .CRD.APIVersion }}
 
-import "github.com/crossplane-contrib/terrajet/pkg/conversion"
+import (
+	"github.com/crossplane-contrib/terrajet/pkg/json"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	{{ .Imports }}
+)
 
 // GetTerraformResourceType returns Terraform resource type for this {{ .CRD.Kind }}
 func (mg *{{ .CRD.Kind }}) GetTerraformResourceType() string {
@@ -18,20 +22,30 @@ func (tr *{{ .CRD.Kind }}) GetTerraformResourceIdField() string {
 
 // GetObservation of this {{ .CRD.Kind }}
 func (tr *{{ .CRD.Kind }}) GetObservation() ([]byte, error) {
-	return conversion.TFParser.Marshal(tr.Status.AtProvider)
+	return json.TFParser.Marshal(tr.Status.AtProvider)
 }
 
 // SetObservation for this {{ .CRD.Kind }}
 func (tr *{{ .CRD.Kind }}) SetObservation(data []byte) error {
-	return conversion.TFParser.Unmarshal(data, &tr.Status.AtProvider)
+	return json.TFParser.Unmarshal(data, &tr.Status.AtProvider)
 }
 
 // GetParameters of this {{ .CRD.Kind }}
-func (tr *{{ .CRD.Kind }}) GetParameters() ([]byte, error) {
-	return conversion.TFParser.Marshal(tr.Spec.ForProvider)
+func (tr *{{ .CRD.Kind }}) GetParameters() (map[string]interface{}, error) {
+	p, err := json.TFParser.Marshal(tr.Spec.ForProvider)
+	if err != nil {
+		return nil, err
+	}
+	base := map[string]interface{}{}
+	{{ .CRD.ExternalNameInjectFn }}(base, meta.GetExternalName(tr))
+	return base, json.JSParser.Unmarshal(p, &base)
 }
 
 // SetParameters for this {{ .CRD.Kind }}
-func (tr *{{ .CRD.Kind }}) SetParameters(data []byte) error {
-	return conversion.TFParser.Unmarshal(data, &tr.Spec.ForProvider)
+func (tr *{{ .CRD.Kind }}) SetParameters(params map[string]interface{}) error {
+	p, err := json.TFParser.Marshal(params)
+	if err != nil {
+		return err
+	}
+	return json.TFParser.Unmarshal(p, &tr.Spec.ForProvider)
 }

--- a/pkg/pipeline/terraformed.go
+++ b/pkg/pipeline/terraformed.go
@@ -54,9 +54,9 @@ func (tg *TerraformedGenerator) Generate(c *resource.Configuration) error {
 	)
 	vars := map[string]interface{}{
 		"CRD": map[string]string{
-			"APIVersion":           c.Version,
-			"Kind":                 c.Kind,
-			"ExternalNameInjectFn": trFile.Imports.UseType(c.ExternalNamer.SelfVarPath),
+			"APIVersion":      c.Version,
+			"Kind":            c.Kind,
+			"ConfigureWithFn": trFile.Imports.UseType(c.ExternalName.SelfVarPath),
 		},
 		"Terraform": map[string]string{
 			// TODO(hasan): This identifier is used to generate external name.

--- a/pkg/pipeline/terraformed.go
+++ b/pkg/pipeline/terraformed.go
@@ -23,12 +23,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/crossplane-contrib/terrajet/pkg/terraform/resource"
-
 	"github.com/muvaf/typewriter/pkg/wrapper"
 	"github.com/pkg/errors"
 
 	"github.com/crossplane-contrib/terrajet/pkg/pipeline/templates"
+	"github.com/crossplane-contrib/terrajet/pkg/terraform/resource"
 )
 
 // NewTerraformedGenerator returns a new TerraformedGenerator.

--- a/pkg/pipeline/terraformed.go
+++ b/pkg/pipeline/terraformed.go
@@ -57,7 +57,7 @@ func (tg *TerraformedGenerator) Generate(c *resource.Configuration) error {
 		"CRD": map[string]string{
 			"APIVersion":           c.Version,
 			"Kind":                 c.Kind,
-			"ExternalNameInjectFn": trFile.Imports.UseType(c.ExternalName.InjectFuncPath),
+			"ExternalNameInjectFn": trFile.Imports.UseType(c.ExternalNamer.SelfVarPath),
 		},
 		"Terraform": map[string]string{
 			// TODO(hasan): This identifier is used to generate external name.

--- a/pkg/terraform/resource/configuration.go
+++ b/pkg/terraform/resource/configuration.go
@@ -67,6 +67,13 @@ type ExternalNamer struct {
 	// they are specified via external name. You can omit only the top level fields.
 	// No field is omitted by default.
 	OmittedFields []string
+
+	// DisableNameInitializer allows you to specify whether the name initializer
+	// that sets external name to metadata.name if none specified should be disabled.
+	// It needs to be disabled for resources whose external name includes information
+	// more than the actual name of the resource, like subscription ID or region
+	// etc. which is unlikely to be included in metadata.name
+	DisableNameInitializer bool
 }
 
 // Configuration is the set of information that you can override at different steps

--- a/pkg/terraform/resource/configuration.go
+++ b/pkg/terraform/resource/configuration.go
@@ -27,10 +27,11 @@ func NopConfigureWithName(_ map[string]interface{}, _ string) {}
 // ConfigurationOption allows setting optional fields of a Configuration object.
 type ConfigurationOption func(*Configuration)
 
-// WithExternalName allows you to set an ExternalNamer for given Configuration.
-func WithExternalName(e ExternalNamer) ConfigurationOption {
+// WithExternalNameConfiguration allows you to set an ExternalNameConfiguration
+// for given Configuration.
+func WithExternalNameConfiguration(e ExternalNameConfiguration) ConfigurationOption {
 	return func(c *Configuration) {
-		c.ExternalNamer = e
+		c.ExternalName = e
 	}
 }
 
@@ -55,10 +56,10 @@ func NewConfiguration(version, kind, terraformResourceType string, opts ...Confi
 	return c
 }
 
-// ExternalNamer contains all information that is necessary for naming operations,
+// ExternalNameConfiguration contains all information that is necessary for naming operations,
 // such as removal of those fields from spec schema and calling Configure function
 // to fill attributes with information given in external name.
-type ExternalNamer struct {
+type ExternalNameConfiguration struct {
 	// SelfVarPath is the Go path to the variable that an instance of this struct
 	// is assigned to. It's necessary since there is no way to know a package
 	// path of a given variable in runtime.
@@ -93,8 +94,8 @@ type Configuration struct {
 	// like aws_rds_cluster.
 	TerraformResourceType string
 
-	// ExternalNamer allows you to specify a custom ExternalNamer.
-	ExternalNamer ExternalNamer
+	// ExternalName allows you to specify a custom ExternalNameConfiguration.
+	ExternalName ExternalNameConfiguration
 
 	// TerraformIDFieldName is the name of the ID field in Terraform state of
 	// the resource. Its default is "id" and in almost all cases, you don't need

--- a/pkg/terraform/resource/configuration.go
+++ b/pkg/terraform/resource/configuration.go
@@ -20,6 +20,10 @@ package resource
 // given name value.
 type ConfigureWithNameFn func(base map[string]interface{}, name string)
 
+// NopConfigureWithName does nothing. It's useful for cases where the external
+// name is calculated by provider and doesn't have any effect on spec fields.
+func NopConfigureWithName(_ map[string]interface{}, _ string) {}
+
 // ConfigurationOption allows setting optional fields of a Configuration object.
 type ConfigurationOption func(*Configuration)
 

--- a/pkg/terraform/resource/configuration.go
+++ b/pkg/terraform/resource/configuration.go
@@ -18,8 +18,6 @@ package resource
 
 import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-func NopExternalNameInject(_ map[string]interface{}, _ string) {}
-
 // NOTE(muvaf): Unfortunately, there is no way to get the package path and the
 // name of an anonymous function in runtime. So, we have to get a full path.
 
@@ -51,13 +49,8 @@ func WithTerraformIDFieldName(n string) ConfigurationOption {
 
 func NewConfiguration(version, kind, terraformResourceType string, sch *schema.Resource, opts ...ConfigurationOption) *Configuration {
 	c := &Configuration{
-		Version: version,
-		Kind:    kind,
-		ExternalName: ExternalName{
-			// TODO(muvaf): Not a good idea.
-			InjectFuncPath: "github.com/crossplane-contrib/terrajet/pkg/terraform/resource.NopExternalNameInject",
-			OmittedFields:  map[string]struct{}{},
-		},
+		Version:               version,
+		Kind:                  kind,
 		TerraformResourceType: terraformResourceType,
 		TerraformIDFieldName:  "id",
 		TerraformSchema:       sch,

--- a/pkg/terraform/resource/configuration.go
+++ b/pkg/terraform/resource/configuration.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package resource
 
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 func NopExternalNameInject(_ map[string]interface{}, _ string) {}
 
 // NOTE(muvaf): Unfortunately, there is no way to get the package path and the
@@ -41,17 +43,24 @@ func WithExternalName(e ExternalName) ConfigurationOption {
 	}
 }
 
-func NewConfiguration(version, kind, terraformResourceType string, opts ...ConfigurationOption) *Configuration {
+func WithTerraformIDFieldName(n string) ConfigurationOption {
+	return func(c *Configuration) {
+		c.TerraformIDFieldName = n
+	}
+}
+
+func NewConfiguration(version, kind, terraformResourceType string, sch *schema.Resource, opts ...ConfigurationOption) *Configuration {
 	c := &Configuration{
-		Version:               version,
-		Kind:                  kind,
-		TerraformResourceType: terraformResourceType,
+		Version: version,
+		Kind:    kind,
 		ExternalName: ExternalName{
 			// TODO(muvaf): Not a good idea.
 			InjectFuncPath: "github.com/crossplane-contrib/terrajet/pkg/terraform/resource.NopExternalNameInject",
 			OmittedFields:  map[string]struct{}{},
 		},
-		TerraformIDFieldName: "id",
+		TerraformResourceType: terraformResourceType,
+		TerraformIDFieldName:  "id",
+		TerraformSchema:       sch,
 	}
 	for _, f := range opts {
 		f(c)
@@ -65,4 +74,5 @@ type Configuration struct {
 	ExternalName          ExternalName
 	TerraformResourceType string
 	TerraformIDFieldName  string
+	TerraformSchema       *schema.Resource
 }

--- a/pkg/terraform/resource/configuration.go
+++ b/pkg/terraform/resource/configuration.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+func NopExternalNameInject(_ map[string]interface{}, _ string) {}
+
+// NOTE(muvaf): Unfortunately, there is no way to get the package path and the
+// name of an anonymous function in runtime. So, we have to get a full path.
+
+type ExternalName struct {
+	// InjectFuncPath is the path to the inject function.
+	// Example: github.com/crossplane/provider-aws/apis/rds/v1alpha1.InjectExternalName
+	// By default, a no-op function is used.
+	InjectFuncPath string
+
+	// OmittedFields are the ones you'd like to be removed from the schema since
+	// they are specified via external name. You can omit only the top level fields.
+	// No field is omitted by default.
+	OmittedFields map[string]struct{}
+}
+
+type ConfigurationOption func(*Configuration)
+
+func WithExternalName(e ExternalName) ConfigurationOption {
+	return func(c *Configuration) {
+		c.ExternalName = e
+	}
+}
+
+func NewConfiguration(version, kind, terraformResourceType string, opts ...ConfigurationOption) *Configuration {
+	c := &Configuration{
+		Version:               version,
+		Kind:                  kind,
+		TerraformResourceType: terraformResourceType,
+		ExternalName: ExternalName{
+			// TODO(muvaf): Not a good idea.
+			InjectFuncPath: "github.com/crossplane-contrib/terrajet/pkg/terraform/resource.NopExternalNameInject",
+			OmittedFields:  map[string]struct{}{},
+		},
+		TerraformIDFieldName: "id",
+	}
+	for _, f := range opts {
+		f(c)
+	}
+	return c
+}
+
+type Configuration struct {
+	Version               string
+	Kind                  string
+	ExternalName          ExternalName
+	TerraformResourceType string
+	TerraformIDFieldName  string
+}

--- a/pkg/terraform/resource/interfaces.go
+++ b/pkg/terraform/resource/interfaces.go
@@ -20,11 +20,14 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 )
 
+// Observable structs can get and set observations in the form of Terraform JSON.
 type Observable interface {
 	GetObservation() ([]byte, error)
 	SetObservation(data []byte) error
 }
 
+// Parameterizable structs can get and set parameters of the managed resource
+// using map form of Terraform JSON.
 type Parameterizable interface {
 	GetParameters() (map[string]interface{}, error)
 	SetParameters(map[string]interface{}) error

--- a/pkg/terraform/resource/interfaces.go
+++ b/pkg/terraform/resource/interfaces.go
@@ -4,17 +4,18 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 )
 
-// TerraformStateHandler handles terraform state
-type TerraformStateHandler interface {
+type Observable interface {
 	GetObservation() ([]byte, error)
 	SetObservation(data []byte) error
-
-	GetParameters() ([]byte, error)
-	SetParameters(data []byte) error
 }
 
-// TerraformMetadataProvider provides Terraform metadata for the Terraform managed resource
-type TerraformMetadataProvider interface {
+type Parameterizable interface {
+	GetParameters() (map[string]interface{}, error)
+	SetParameters(map[string]interface{}) error
+}
+
+// MetadataProvider provides Terraform metadata for the Terraform managed resource
+type MetadataProvider interface {
 	GetTerraformResourceType() string
 	GetTerraformResourceIdField() string
 }
@@ -23,6 +24,7 @@ type TerraformMetadataProvider interface {
 type Terraformed interface {
 	resource.Managed
 
-	TerraformMetadataProvider
-	TerraformStateHandler
+	MetadataProvider
+	Observable
+	Parameterizable
 }

--- a/pkg/terraform/resource/interfaces.go
+++ b/pkg/terraform/resource/interfaces.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resource
 
 import (

--- a/pkg/tfcli/options.go
+++ b/pkg/tfcli/options.go
@@ -81,12 +81,9 @@ func WithResourceType(resourceType string) ClientOption {
 // be used in the generated  Terraform configuration. resourceBody
 // must be a whole JSON document containing the serialized resource
 // parameters.
-func WithResourceBody(resourceBody []byte) ClientOption {
+func WithResourceBody(body map[string]interface{}) ClientOption {
 	return func(c *Client) {
-		// common controller serializes resource parameter block into
-		// a JSON object. However, we would like to add new fields
-		// to this JSON object and thus here we capture only the parameters.
-		c.resource.Body = resourceBody[1 : len(resourceBody)-1]
+		c.resource.Body = body
 	}
 }
 
@@ -197,7 +194,7 @@ func (c Client) validate() error {
 type Resource struct {
 	LabelType string
 	LabelName string
-	Body      []byte
+	Body      map[string]interface{}
 	Lifecycle Lifecycle
 }
 

--- a/pkg/tfcli/templates/main.tf.json.tpl
+++ b/pkg/tfcli/templates/main.tf.json.tpl
@@ -20,11 +20,6 @@
         "{{ .Resource.LabelType }}": {
             "{{ .Resource.LabelName }}": {
                 {{ .Resource.Body | printf "%s" }}
-                {{ if .Lifecycle.PreventDestroy -}}
-                    ,"lifecycle" : {
-                    "prevent_destroy": true
-                    }
-                {{ end }}
             }
         }
     }

--- a/pkg/tfcli/templates/main.tf.json.tpl
+++ b/pkg/tfcli/templates/main.tf.json.tpl
@@ -18,9 +18,7 @@
 
     "resource": {
         "{{ .Resource.LabelType }}": {
-            "{{ .Resource.LabelName }}": {
-                {{ .Resource.Body | printf "%s" }}
-            }
+            "{{ .Resource.LabelName }}": {{ .Resource.Body | printf "%s" }}
         }
     }
 }


### PR DESCRIPTION
### Description of your changes

First stab at opening up an interface for per-resource configuration and external name function is the first implementation. As described in https://github.com/crossplane-contrib/terrajet/issues/11#issuecomment-919154858 we're going to ask authors to provide a set of fields to omit from top level spec and give a function that will take external name and set the necessary fields in the output HCL before actual parameters are applied.

Fixes https://github.com/crossplane-contrib/terrajet/issues/11

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Code compiles with provider-tf-aws but I haven't tried provisioning a resource. See https://github.com/crossplane-contrib/provider-tf-aws/pull/19

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
