### PR TITLE
Pass maximum concurrent reconciles options to generated controllers

### DIFF
--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -19,7 +19,7 @@ import (
 )
 
 // Setup adds a controller that reconciles {{ .CRD.Kind }} managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
 	name := managed.ControllerName({{ .TypePackageAlias }}{{ .CRD.Kind }}GroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}GroupVersionKind),
@@ -30,7 +30,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{RateLimiter: rl}).
+		WithOptions(controller.Options{RateLimiter: rl, MaxConcurrentReconciles: concurrency}).
 		For(&{{ .TypePackageAlias }}{{ .CRD.Kind }}{}).
 		Complete(r)
 }

--- a/pkg/pipeline/templates/setup.go.tmpl
+++ b/pkg/pipeline/templates/setup.go.tmpl
@@ -27,13 +27,13 @@ import (
 
 // Setup creates all controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter) error{
+func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, concurrency int) error {
+	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, int) error{
 		{{- range $alias := .Aliases }}
 		{{ $alias }}Setup,
 		{{- end }}
 	} {
-		if err := setup(mgr, l, wl); err != nil {
+		if err := setup(mgr, l, wl, concurrency); err != nil {
 			return err
 		}
 	}

--- a/pkg/tfcli/init.go
+++ b/pkg/tfcli/init.go
@@ -194,8 +194,14 @@ func (c *Client) checkOperation() error {
 	}
 	// check if operation timed out if timeout is configured
 	if c.timeout != nil && xpState.Ts.Before(time.Now()) {
-		// then async operation has timed out
-		return c.removeStateStore()
+		storeExists, err := c.pathExists(filepath.Join(c.wsPath, fileStore), false)
+		if err != nil {
+			return err
+		}
+		// then async operation has timed out before generating a store file
+		if !storeExists {
+			return c.removeStateStore()
+		}
 	}
 	return tferrors.NewOperationInProgressError(xpState.Operation)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes a change in terrajet that allows terrajet-based providers to set the maximum concurrent reconciles options for their controllers. The default value stays unmodified at 1. 
It also contains a fix for `tfcli`, where we now consume a store file if the pipeline had a chance to generate it before timing out.


I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
Manually tested this in the scope of the scalability tests I'm running with #55. I will provide more context and a detailed discussion there for the motivation behind this PR.