### PR TITLE
Read provider source and version with ProviderSetup function

### DIFF
--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -19,11 +19,11 @@ import (
 )
 
 // Setup adds a controller that reconciles {{ .CRD.Kind }} managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, concurrency int) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, ps terraform.ProviderSetupFn, concurrency int) error {
 	name := managed.ControllerName({{ .TypePackageAlias }}{{ .CRD.Kind }}GroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}GroupVersionKind),
-		managed.WithExternalConnecter(terraform.NewConnector(mgr.GetClient(), l, {{ .ProviderConfigBuilderPackageAlias }}ProviderConfigBuilder)),
+		managed.WithExternalConnecter(terraform.NewConnector(mgr.GetClient(), l, ps)),
 		managed.WithLogger(l.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		{{- if .DisableNameInitializer }}

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -19,7 +19,7 @@ import (
 )
 
 // Setup adds a controller that reconciles {{ .CRD.Kind }} managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, ps terraform.ProviderSetupFn, concurrency int) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, ps terraform.SetupFn, concurrency int) error {
 	name := managed.ControllerName({{ .TypePackageAlias }}{{ .CRD.Kind }}GroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}GroupVersionKind),

--- a/pkg/pipeline/templates/setup.go.tmpl
+++ b/pkg/pipeline/templates/setup.go.tmpl
@@ -27,13 +27,13 @@ import (
 
 // Setup creates all controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, concurrency int) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, int) error{
+func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, ps terraform.ProviderSetupFn, concurrency int) error {
+	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, terraform.ProviderSetupFn, int) error{
 		{{- range $alias := .Aliases }}
 		{{ $alias }}Setup,
 		{{- end }}
 	} {
-		if err := setup(mgr, l, wl, concurrency); err != nil {
+		if err := setup(mgr, l, wl, ps, concurrency); err != nil {
 			return err
 		}
 	}

--- a/pkg/pipeline/templates/setup.go.tmpl
+++ b/pkg/pipeline/templates/setup.go.tmpl
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/crossplane-contrib/terrajet/pkg/terraform"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
 	{{ .Imports }}
@@ -27,8 +28,8 @@ import (
 
 // Setup creates all controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, ps terraform.ProviderSetupFn, concurrency int) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, terraform.ProviderSetupFn, int) error{
+func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, ps terraform.SetupFn, concurrency int) error {
+	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, terraform.SetupFn, int) error{
 		{{- range $alias := .Aliases }}
 		{{ $alias }}Setup,
 		{{- end }}

--- a/pkg/terraform/controller.go
+++ b/pkg/terraform/controller.go
@@ -40,25 +40,25 @@ const (
 	errUnexpectedObject = "the managed resource is not an Terraformed resource"
 )
 
-// ProviderConfigFn is a function that returns provider specific configuration
+// ProviderSetupFn is a function that returns provider specific configuration
 // like provider credentials used to connect to cloud APIs.
-type ProviderConfigFn func(ctx context.Context, client client.Client, mg xpresource.Managed) ([]byte, error)
+type ProviderSetupFn func(ctx context.Context, client client.Client, mg xpresource.Managed) (tfcli.ProviderRequirement, tfcli.ProviderConfiguration, error)
 
 // NewConnector returns a new Connector object.
-func NewConnector(kube client.Client, l logging.Logger, providerConfigFn ProviderConfigFn) *Connector {
+func NewConnector(kube client.Client, l logging.Logger, ps ProviderSetupFn) *Connector {
 	return &Connector{
-		kube:           kube,
-		logger:         l,
-		providerConfig: providerConfigFn,
+		kube:          kube,
+		logger:        l,
+		providerSetup: ps,
 	}
 }
 
 // Connector initializes the external client with credentials and other configuration
 // parameters.
 type Connector struct {
-	kube           client.Client
-	providerConfig ProviderConfigFn
-	logger         logging.Logger
+	kube          client.Client
+	providerSetup ProviderSetupFn
+	logger        logging.Logger
 }
 
 // Connect makes sure the underlying client is ready to issue requests to the
@@ -69,12 +69,12 @@ func (c *Connector) Connect(ctx context.Context, mg xpresource.Managed) (managed
 		return nil, errors.New(errUnexpectedObject)
 	}
 
-	pc, err := c.providerConfig(ctx, c.kube, mg)
+	pr, pc, err := c.providerSetup(ctx, c.kube, mg)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get provider config")
 	}
 
-	tfCli, err := conversion.BuildClientForResource(ctx, tr, tfcli.WithLogger(c.logger), tfcli.WithProviderConfiguration(pc))
+	tfCli, err := conversion.BuildClientForResource(ctx, tr, tfcli.WithLogger(c.logger), tfcli.WithProviderConfiguration(pc), tfcli.WithProviderRequirement(pr))
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot build tf client for resource")
 	}

--- a/pkg/tfcli/client.go
+++ b/pkg/tfcli/client.go
@@ -69,7 +69,7 @@ const (
 // Client is an implementation of types.Client and represents a
 // Terraform client capable of running Refresh, Apply, Destroy pipelines.
 type Client struct {
-	provider Provider
+	setup    TerraformSetup
 	resource Resource
 	handle   string
 	tfState  []byte

--- a/pkg/tfcli/init.go
+++ b/pkg/tfcli/init.go
@@ -145,6 +145,10 @@ func (c Client) generateTFConfiguration(preventDestroy bool) ([]byte, error) {
 	c.resource.Body["lifecycle"] = map[string]bool{
 		"prevent_destroy": preventDestroy,
 	}
+	config, err := json.JSParser.Marshal(c.setup.Configuration)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot marshal provider config")
+	}
 	body, err := json.JSParser.Marshal(c.resource.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot marshal resource body")
@@ -152,9 +156,9 @@ func (c Client) generateTFConfiguration(preventDestroy bool) ([]byte, error) {
 	var buff bytes.Buffer
 	vars := map[string]interface{}{
 		"Provider": map[string]interface{}{
-			"Source":        c.provider.Requirement.Source,
-			"Version":       c.provider.Requirement.Version,
-			"Configuration": c.provider.Configuration,
+			"Source":        c.setup.Requirement.Source,
+			"Version":       c.setup.Requirement.Version,
+			"Configuration": config,
 		},
 		"Resource": map[string]interface{}{
 			"LabelType": c.resource.LabelType,

--- a/pkg/tfcli/init.go
+++ b/pkg/tfcli/init.go
@@ -152,8 +152,8 @@ func (c Client) generateTFConfiguration(preventDestroy bool) ([]byte, error) {
 	var buff bytes.Buffer
 	vars := map[string]interface{}{
 		"Provider": map[string]interface{}{
-			"Source":        c.provider.Source,
-			"Version":       c.provider.Version,
+			"Source":        c.provider.Requirement.Source,
+			"Version":       c.provider.Requirement.Version,
 			"Configuration": c.provider.Configuration,
 		},
 		"Resource": map[string]interface{}{

--- a/pkg/tfcli/options.go
+++ b/pkg/tfcli/options.go
@@ -19,7 +19,6 @@ package tfcli
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -37,9 +36,6 @@ const (
 	errValidationNoHandle    = "no workspace handle has been configured"
 	fmtErrValidationResource = "invalid resource specification: both type and name are required: type=%q and name=%q"
 	fmtErrValidationProvider = "invalid provider specification: both source and version are required: source=%q and version=%q"
-	// env variable names
-	envTFProviderVersion = "XP_TERRAFORM_PROVIDER_VERSION"
-	envTFProviderSource  = "XP_TERRAFORM_PROVIDER_SOURCE"
 
 	fmtResourceAddress = "%s.%s"
 )
@@ -158,12 +154,6 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 	if c.timeout == nil {
 		d := defaultAsyncTimeout
 		c.timeout = &d
-	}
-	if c.provider.Version == "" {
-		c.provider.Version = os.Getenv(envTFProviderVersion)
-	}
-	if c.provider.Source == "" {
-		c.provider.Source = os.Getenv(envTFProviderSource)
 	}
 	if err := c.validate(); err != nil {
 		return nil, err

--- a/pkg/tfcli/options.go
+++ b/pkg/tfcli/options.go
@@ -35,7 +35,8 @@ const (
 	errValidationNoLogger    = "no logger has been configured"
 	errValidationNoHandle    = "no workspace handle has been configured"
 	fmtErrValidationResource = "invalid resource specification: both type and name are required: type=%q and name=%q"
-	fmtErrValidationProvider = "invalid provider specification: both source and version are required: source=%q and version=%q"
+	fmtErrValidationProvider = "invalid setup.requirement specification: both source and version are required: source=%q and version=%q"
+	fmtErrValidationVersion  = "invalid setup specification, Terraform version not provided"
 
 	fmtResourceAddress = "%s.%s"
 )
@@ -83,19 +84,11 @@ func WithResourceBody(body map[string]interface{}) ClientOption {
 	}
 }
 
-// WithProviderConfiguration sets the Terraform provider
-// configuration block to be used in the generated Terraform configuration
-func WithProviderConfiguration(conf []byte) ClientOption {
+// WithTerraformSetup sets the Terraform configuration which
+// contains provider requirement, configuration and Terraform version
+func WithTerraformSetup(setup TerraformSetup) ClientOption {
 	return func(c *Client) {
-		c.provider.Configuration = conf
-	}
-}
-
-// WithProviderRequirement sets the Terraform provider
-// requirement to be used in the generated Terraform configuration
-func WithProviderRequirement(req ProviderRequirement) ClientOption {
-	return func(c *Client) {
-		c.provider.Requirement = req
+		c.setup = setup
 	}
 }
 
@@ -127,7 +120,7 @@ func WithStateStoreFs(fs afero.Fs) ClientOption {
 // Terraform Refresh, Apply, Destroy command pipelines.
 // The workspace configured with WithHandle option is initialized
 // for the returned Client. All Terraform resource block generation options
-// (WithResource*), all Terraform provider block generation options
+// (WithResource*), all Terraform setup block generation options
 // (WithProvider*), the workspace handle option (WithHandle) and a
 // logger (WithLogger) must have been configured for the Client.
 // Returns an error if the supplied options cannot be validated, or
@@ -160,7 +153,7 @@ func (c Client) validate() error {
 	if err := c.resource.validate(); err != nil {
 		return err
 	}
-	if err := c.provider.validate(); err != nil {
+	if err := c.setup.validate(); err != nil {
 		return err
 	}
 	if c.logger == nil {
@@ -199,22 +192,27 @@ func (r Resource) GetAddress() string {
 	return fmt.Sprintf(fmtResourceAddress, r.LabelType, r.LabelName)
 }
 
-// ProviderRequirement holds values for the Terraform HCL provider requirements
+// ProviderRequirement holds values for the Terraform HCL setup requirements
 type ProviderRequirement struct {
 	Source  string
 	Version string
 }
 
-// ProviderConfiguration holds the provider configuration body
-type ProviderConfiguration []byte
+// ProviderConfiguration holds the setup configuration body
+type ProviderConfiguration map[string]interface{}
 
-// Provider holds values for the Terraform HCL provider block's source, version and configuration body
-type Provider struct {
+// TerraformSetup holds values for the Terraform version and setup
+// requirements and configuration body
+type TerraformSetup struct {
+	Version       string
 	Requirement   ProviderRequirement
 	Configuration ProviderConfiguration
 }
 
-func (p Provider) validate() error {
+func (p TerraformSetup) validate() error {
+	if p.Version == "" {
+		return errors.New(fmtErrValidationVersion)
+	}
 	if p.Requirement.Source == "" || p.Requirement.Version == "" {
 		return errors.Errorf(fmtErrValidationProvider, p.Requirement.Source, p.Requirement.Version)
 	}

--- a/pkg/tfcli/options.go
+++ b/pkg/tfcli/options.go
@@ -91,19 +91,11 @@ func WithProviderConfiguration(conf []byte) ClientOption {
 	}
 }
 
-// WithProviderSource sets the Terraform provider
-// source to be used in the generated Terraform configuration
-func WithProviderSource(source string) ClientOption {
+// WithProviderRequirement sets the Terraform provider
+// requirement to be used in the generated Terraform configuration
+func WithProviderRequirement(req ProviderRequirement) ClientOption {
 	return func(c *Client) {
-		c.provider.Source = source
-	}
-}
-
-// WithProviderVersion sets the Terraform provider
-// version to be used in the generated Terraform configuration
-func WithProviderVersion(version string) ClientOption {
-	return func(c *Client) {
-		c.provider.Version = version
+		c.provider.Requirement = req
 	}
 }
 
@@ -207,16 +199,24 @@ func (r Resource) GetAddress() string {
 	return fmt.Sprintf(fmtResourceAddress, r.LabelType, r.LabelName)
 }
 
+// ProviderRequirement holds values for the Terraform HCL provider requirements
+type ProviderRequirement struct {
+	Source  string
+	Version string
+}
+
+// ProviderConfiguration holds the provider configuration body
+type ProviderConfiguration []byte
+
 // Provider holds values for the Terraform HCL provider block's source, version and configuration body
 type Provider struct {
-	Source        string
-	Version       string
-	Configuration []byte
+	Requirement   ProviderRequirement
+	Configuration ProviderConfiguration
 }
 
 func (p Provider) validate() error {
-	if p.Source == "" || p.Version == "" {
-		return errors.Errorf(fmtErrValidationProvider, p.Source, p.Version)
+	if p.Requirement.Source == "" || p.Requirement.Version == "" {
+		return errors.Errorf(fmtErrValidationProvider, p.Requirement.Source, p.Requirement.Version)
 	}
 	return nil
 }

--- a/pkg/tfcli/templates/main.tf.json.tpl
+++ b/pkg/tfcli/templates/main.tf.json.tpl
@@ -2,8 +2,8 @@
     "terraform": {
         "required_providers": {
             "tf-provider": {
-                "source":  "{{ .Provider.Requirement.Source }}",
-                "version": "{{ .Provider.Requirement.Version }}"
+                "source":  "{{ .Provider.Source }}",
+                "version": "{{ .Provider.Version }}"
             }
         }
     },

--- a/pkg/tfcli/templates/main.tf.json.tpl
+++ b/pkg/tfcli/templates/main.tf.json.tpl
@@ -2,8 +2,8 @@
     "terraform": {
         "required_providers": {
             "tf-provider": {
-                "source":  "{{ .Provider.Source }}",
-                "version": "{{ .Provider.Version }}"
+                "source":  "{{ .Provider.Requirement.Source }}",
+                "version": "{{ .Provider.Requirement.Version }}"
             }
         }
     },


### PR DESCRIPTION
### Description of your changes

This PR:

- Reverts recently introduced [workaround](https://github.com/crossplane-contrib/terrajet/pull/62) to pass provider requirements via env vars.
- Extends (and renames as ProviderSetupFn) existing ProviderConfigFn to also pass provider source and version

Fixes #51 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested with https://github.com/crossplane-contrib/provider-tf-aws/pull/20

[contribution process]: https://git.io/fj2m9
