### PR TITLE
tfcli: disable refresh from plan command so that we do not call it twice

### DIFF
--- a/pkg/tfcli/refresh.go
+++ b/pkg/tfcli/refresh.go
@@ -110,7 +110,7 @@ func (c *Client) observe(ctx context.Context) (model.RefreshResult, error) {
 	}
 	// now try to run the refresh pipeline synchronously
 	if err := c.syncPipeline(ctx, true, "sh", "-c",
-		fmt.Sprintf("%s apply -refresh-only -auto-approve -input=false && %s plan -detailed-exitcode -input=false",
+		fmt.Sprintf("%s apply -refresh-only -auto-approve -input=false && %s plan -detailed-exitcode -refresh=false -input=false",
 			pathTerraform, pathTerraform)); err != nil {
 		return result, err
 	}


### PR DESCRIPTION
### Description of your changes

`terraform plan` command has `-refresh=false` flag that we can use to avoid refreshing the local state again since it's already refreshed. This should reduce observe time to close to half since refresh calls takes the most.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually.

Terraform log before the change:
```
$ terraform apply -refresh-only -auto-approve -input=false && terraform plan -detailed-exitcode -input=false
aws_vpc.sample-vpc: Refreshing state... [id=vpc-0d2e0edf6196cf545]

No changes. Your infrastructure still matches the configuration.

Terraform has checked that the real remote objects still match the result of your most recent changes, and found no differences.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
aws_vpc.sample-vpc: Refreshing state... [id=vpc-0d2e0edf6196cf545]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

After the change:
```
$ terraform apply -refresh-only -auto-approve -input=false && terraform plan -detailed-exitcode -refresh=false -input=false
aws_vpc.sample-vpc: Refreshing state... [id=vpc-0d2e0edf6196cf545]

No changes. Your infrastructure still matches the configuration.

Terraform has checked that the real remote objects still match the result of your most recent changes, and found no differences.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
