### PR TITLE
tfcli: use json output of terraform plan to parse changes

### DIFF
--- a/pkg/tfcli/client.go
+++ b/pkg/tfcli/client.go
@@ -50,8 +50,6 @@ const (
 	errNoProcessState   = "failed to store process state: no process state"
 	errStore            = "failed to store process state"
 	errCheckExitCode    = "failed to check process exit code"
-	errNoPlan           = "plan line not found in Terraform CLI output"
-	errPlan             = "failed to parse the Terraform plan"
 	errWriteFile        = "failed to write file"
 	errReadFile         = "failed to read file"
 	fmtErrCheckTFState  = "failed to check Terraform state lock: %s"
@@ -60,8 +58,6 @@ const (
 	fmtErrStoreState    = "failed to store state into file: %s"
 	fmtErrAsyncRun      = "failed to run async Terraform pipeline %q with args: %v: in dir: %s"
 	fmtErrSyncRun       = "failed to run sync Terraform pipeline %q with args: %v: in dir: %s"
-
-	regexpPlanLine = `Plan:.*([\d+]).*to add,.*([\d+]) to change, ([\d+]) to destroy`
 
 	tfMsgNonExistentResource = "Cannot import non-existent remote object"
 )


### PR DESCRIPTION
### Description of your changes

The log of `terraform plan` gives enough information about what's planned that we don't need to rely on the returned code to assess whether we are up-to-date or not. I have been confused about what's happening here when I was working on state reproduce issue.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually with provider-tf-aws.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
