### PR TITLE
Put Terraform provider source and version into configuration

### DIFF
--- a/pkg/tfcli/init.go
+++ b/pkg/tfcli/init.go
@@ -157,6 +157,10 @@ func (c Client) generateTFConfiguration(preventDestroy bool) ([]byte, error) {
 	vars := map[string]interface{}{
 		"Provider": map[string]interface{}{
 			"Configuration": config,
+			"Requirement": map[string]interface{}{
+				"Source":  c.setup.Requirement.Source,
+				"Version": c.setup.Requirement.Version,
+			},
 		},
 		"Resource": map[string]interface{}{
 			"LabelType": c.resource.LabelType,

--- a/pkg/tfcli/templates/main.tf.json.tpl
+++ b/pkg/tfcli/templates/main.tf.json.tpl
@@ -2,8 +2,8 @@
     "terraform": {
         "required_providers": {
             "tf-provider": {
-                "source":  "{{ .Provider.Source }}",
-                "version": "{{ .Provider.Version }}"
+                "source":  "{{ .Provider.Requirement.Source }}",
+                "version": "{{ .Provider.Requirement.Version }}"
             }
         }
     },


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Looks like we are missing Terraform provider source and version in the generated configuration.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Manually verified that the generated configuration file (`main.tf.json`) now contains the provider source and version info passed with the provider's `--terraform-provider-source` and `--terraform-provider-version` command-line options.

[contribution process]: https://git.io/fj2m9
