### PR TITLE
Skip late-initialization of omiempty-tagged maps with zero-length observations

### DIFF
--- a/pkg/resource/lateinit.go
+++ b/pkg/resource/lateinit.go
@@ -89,7 +89,7 @@ func zeroValueJSONOmitEmptyFilter(cName string) ValueFilter {
 			return false
 		case v.IsZero():
 			return true
-		case k == reflect.Slice && v.Len() == 0:
+		case (k == reflect.Slice || k == reflect.Map) && v.Len() == 0:
 			return true
 		case k == reflect.Ptr && v.Elem().IsZero():
 			return true

--- a/pkg/resource/lateinit_test.go
+++ b/pkg/resource/lateinit_test.go
@@ -72,7 +72,7 @@ func TestLateInitialize(t *testing.T) {
 	}
 
 	type nestedStruct9 struct {
-		F1 map[string][]string
+		F1 map[string][]string `json:"f_1,omitempty"`
 	}
 
 	type nestedStruct10 struct {
@@ -511,6 +511,17 @@ func TestLateInitialize(t *testing.T) {
 			},
 			wantModified: false,
 			wantCRObject: &nestedStruct6{},
+		},
+		"TestSkipOmitemptyTaggedMapElem": {
+			args: args{
+				desiredObject: &nestedStruct9{},
+				observedObject: &nestedStruct9{
+					F1: map[string][]string{},
+				},
+				opts: []GenericLateInitializerOption{WithZeroValueJSONOmitEmptyFilter("F1")},
+			},
+			wantModified: false,
+			wantCRObject: &nestedStruct9{},
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #82

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested successfully against `provider-tf-aws` with an example `v1alpha1.RdsCluster` resource.

[contribution process]: https://git.io/fj2m9
