### PR TITLE
Fix invalid key syntax for paths with indexes

### DIFF
--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -73,6 +73,11 @@ func GetConnectionDetails(from map[string]interface{}, mapping map[string]string
 			if err != nil {
 				return nil, errors.Wrapf(err, errFmtCannotGetStringForFieldPath, fp)
 			}
+			// Note(turkenh): k8s secrets uses a strict regex to validate secret
+			// keys which does not allow having brackets inside. So, we need to
+			// do a conversion to be able to store as connection secret keys.
+			// See https://github.com/crossplane-contrib/terrajet/pull/94 for
+			// more details.
 			k, err := fieldPathToSecretKey(fp)
 			if err != nil {
 				return nil, errors.Wrapf(err, "cannot convert fieldpath %q to secret key", fp)


### PR DESCRIPTION
### Description of your changes

As @ulucinar revealed in #93 Kubernetes secret keys use a limited character set to validate secret keys which does not include `[` and `]` which we were using in keys for indexed paths.

We need to store this information in connection details secret but still have to be able to construct it back without losing information to build the tfstate.

This PR fixed the problem by converting:

`kubeconfig[0].password`

to 

`kubeconfig.0.password`

There is one edge which could break this, that is, keys containing dots inside (e.g. `ip_addresses[crossplane.io]`). We are not sure how common is this among the sensitive terraform attributes but this case also handled as follows:

`ip_addresses[crossplane.io]`

to 

`ip_addresses...crossplane.io...`

Fixes #93

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests
I also verified k8s secret could be created with keys three dots like `abc...my.cool.key...` which corresponds to `abc[my.cool.key]`

[contribution process]: https://git.io/fj2m9
