### PR TITLE
builder: all tf tags should have omitempty property

### DIFF
--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -152,12 +152,12 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 		switch {
 		case isObservation(sch):
 			obsFields = append(obsFields, field)
-			obsTags = append(obsTags, fmt.Sprintf(`json:"%s,omitempty" tf:"%s"`, jsonTag, tfTag))
+			obsTags = append(obsTags, fmt.Sprintf(`json:"%s,omitempty" tf:"%s,omitempty"`, jsonTag, tfTag))
 		default:
 			if sch.Optional {
-				paramTags = append(paramTags, fmt.Sprintf(`json:"%s,omitempty" tf:"%s"`, jsonTag, tfTag))
+				paramTags = append(paramTags, fmt.Sprintf(`json:"%s,omitempty" tf:"%s,omitempty"`, jsonTag, tfTag))
 			} else {
-				paramTags = append(paramTags, fmt.Sprintf(`json:"%s" tf:"%s"`, jsonTag, tfTag))
+				paramTags = append(paramTags, fmt.Sprintf(`json:"%s" tf:"%s,omitempty"`, jsonTag, tfTag))
 			}
 			req := !sch.Optional
 			comment.Required = &req


### PR DESCRIPTION
### Description of your changes

I ran into a case where `terraform plan` reported changes because of server-side assigned values. Normally, we'd see those values in our parameters but when the first plan check runs late-init update is not yet issued. Also, there will be cases where we ignore late-init, so it's safer to omit the empty structs in `main.tf.json`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually with RDS Cluster.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
