### PR TITLE
builder: fix camel case issue in reference field json tag

### DIFF
--- a/pkg/types/reference.go
+++ b/pkg/types/reference.go
@@ -44,8 +44,8 @@ func (g *Builder) generateReferenceFields(t *types.TypeName, f *types.Var, r con
 
 	rn := NewNameFromCamel(rfn)
 	sn := NewNameFromCamel(sfn)
-	refTag := fmt.Sprintf(`json:"%s,omitempty" tf:"-"`, rn.LowerCamel)
-	selTag := fmt.Sprintf(`json:"%s,omitempty" tf:"-"`, sn.LowerCamel)
+	refTag := fmt.Sprintf(`json:"%s,omitempty" tf:"-"`, rn.LowerCamelComputed)
+	selTag := fmt.Sprintf(`json:"%s,omitempty" tf:"-"`, sn.LowerCamelComputed)
 
 	var tr types.Type
 	tr = types.NewPointer(typeReferenceField)


### PR DESCRIPTION
### Description of your changes

We need to use the computed lower camel name, otherwise `subnetId` field ends up having `subnetIDRef` as reference field since `LowerCamel` uses the acronym list.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
