### PR TITLE
Pass provider credentials as environment variables

### DIFF
--- a/pkg/terraform/store.go
+++ b/pkg/terraform/store.go
@@ -52,6 +52,7 @@ type Setup struct {
 	Version       string
 	Requirement   ProviderRequirement
 	Configuration ProviderConfiguration
+	Env           []string
 }
 
 // WorkspaceStoreOption lets you configure the workspace store.
@@ -127,6 +128,7 @@ func (ws *WorkspaceStore) Workspace(ctx context.Context, c resource.SecretClient
 	if xpresource.Ignore(os.IsNotExist, err) != nil {
 		return nil, errors.Wrap(err, "cannot stat init lock file")
 	}
+	w.env = ts.Env
 	// We need to initialize only if the workspace hasn't been initialized yet.
 	if !os.IsNotExist(err) {
 		return w, nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #99

This PR proposes a change in which we pass provider specific credentials as environment variables.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested with provider-tf-azure.

[contribution process]: https://git.io/fj2m9
