### PR TITLE
Capture Terraform resource schema version with resource.Terraformed

### DIFF
--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -88,3 +88,7 @@ func (tr *{{ .CRD.Kind }}) LateInitialize(attrs []byte) (bool, error) {
 	return li.LateInitialize(&tr.Spec.ForProvider, params)
 }
 
+// GetTerraformSchemaVersion returns the associated Terraform schema version
+func (tr *{{ .CRD.Kind }}) GetTerraformSchemaVersion() int {
+    return {{ .Terraform.SchemaVersion }}
+}

--- a/pkg/pipeline/terraformed.go
+++ b/pkg/pipeline/terraformed.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/muvaf/typewriter/pkg/wrapper"
 	"github.com/pkg/errors"
 
@@ -47,7 +48,7 @@ type TerraformedGenerator struct {
 }
 
 // Generate writes generated Terraformed interface functions
-func (tg *TerraformedGenerator) Generate(c *config.Resource) error {
+func (tg *TerraformedGenerator) Generate(c *config.Resource, sch *schema.Resource) error {
 	trFile := wrapper.NewFile(tg.pkg.Path(), tg.pkg.Name(), templates.TerraformedTemplate,
 		wrapper.WithGenStatement(GenStatement),
 		wrapper.WithHeaderPath("hack/boilerplate.go.txt"), // todo
@@ -62,7 +63,7 @@ func (tg *TerraformedGenerator) Generate(c *config.Resource) error {
 			"Kind":                  c.Kind,
 			"ConfigureExternalName": cfgPath,
 		},
-		"Terraform": map[string]string{
+		"Terraform": map[string]interface{}{
 			// TODO(hasan): This identifier is used to generate external name.
 			//  However, external-name generation is not as straightforward as
 			//  just finding out the identifier field since Terraform uses
@@ -71,6 +72,7 @@ func (tg *TerraformedGenerator) Generate(c *config.Resource) error {
 			//  https://github.com/crossplane-contrib/terrajet/issues/11
 			"IdentifierField": c.TerraformIDFieldName,
 			"ResourceType":    c.TerraformResourceType,
+			"SchemaVersion":   sch.SchemaVersion,
 		},
 		"SensitiveFields": c.Sensitive.GetFieldPaths(),
 		"LateInitializer": map[string]interface{}{

--- a/pkg/resource/fake/terraformed.go
+++ b/pkg/resource/fake/terraformed.go
@@ -17,10 +17,11 @@ limitations under the License.
 package fake
 
 import (
-	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 )
 
 // Observable is mock Observable.
@@ -59,6 +60,7 @@ func (p *Parameterizable) SetParameters(data map[string]interface{}) error {
 type MetadataProvider struct {
 	Type                     string
 	IDField                  string
+	SchemaVersion            int
 	ConnectionDetailsMapping map[string]string
 }
 
@@ -70,6 +72,11 @@ func (mp *MetadataProvider) GetTerraformResourceType() string {
 // GetTerraformResourceIDField is a mock.
 func (mp *MetadataProvider) GetTerraformResourceIDField() string {
 	return mp.IDField
+}
+
+// GetTerraformSchemaVersion is a mock.
+func (mp *MetadataProvider) GetTerraformSchemaVersion() int {
+	return mp.SchemaVersion
 }
 
 // GetConnectionDetailsMapping is a mock.

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -38,6 +38,7 @@ type Parameterizable interface {
 type MetadataProvider interface {
 	GetTerraformResourceType() string
 	GetTerraformResourceIDField() string
+	GetTerraformSchemaVersion() int
 	GetConnectionDetailsMapping() map[string]string
 }
 

--- a/pkg/terraform/files.go
+++ b/pkg/terraform/files.go
@@ -22,9 +22,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
+
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 
 	"github.com/crossplane-contrib/terrajet/pkg/resource"
 	"github.com/crossplane-contrib/terrajet/pkg/resource/json"
@@ -125,7 +126,7 @@ func (fp *FileProducer) WriteTFState() error {
 			ProviderConfig: fmt.Sprintf(`provider["registry.terraform.io/%s"]`, fp.Setup.Requirement.Source),
 			Instances: []json.InstanceObjectStateV4{
 				{
-					SchemaVersion: 0,
+					SchemaVersion: uint64(fp.Resource.GetTerraformSchemaVersion()),
 					PrivateRaw:    privateRaw,
 					AttributesRaw: attr,
 				},


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #116 

The PR captures the available Terraform resource schema version as part of terrajet's resource.Terraformed. For certain resources, it turns out that the schema version is not 0 and that version info is already available in the native provider. With this PR we should be able to capture the correct schema version without manual configuration.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I have successfully tested these changes together with https://github.com/crossplane-contrib/provider-tf-azure/pull/64 using the following example manifests:
- https://github.com/crossplane-contrib/provider-tf-azure/blob/3357a1ee3ed444abff09fff09caacb7c942455c1/examples/storage/storageaccount.yaml
- https://github.com/crossplane-contrib/provider-tf-azure/blob/3357a1ee3ed444abff09fff09caacb7c942455c1/examples/storage/storagecontainer.yaml
- https://github.com/crossplane-contrib/provider-tf-azure/blob/3357a1ee3ed444abff09fff09caacb7c942455c1/examples/storage/storageblob.yaml

```k get managed
NAME                                                    READY   SYNCED   EXTERNAL-NAME                                                              AGE
resourcegroup.resource.azure.tf.crossplane.io/example   True    True     /subscriptions/038f2b7c-3265-43b8-8624-c9ad5da610a8/resourceGroups/alper   5m30s

NAME                                                    READY   SYNCED   EXTERNAL-NAME                                                                                                                                   AGE
storageaccount.storage.azure.tf.crossplane.io/example   True    True     /subscriptions/038f2b7c-3265-43b8-8624-c9ad5da610a8/resourceGroups/alper/providers/Microsoft.Storage/storageAccounts/crossplaneexamplestoracc   4m9s

NAME                                                 READY   SYNCED   EXTERNAL-NAME                                                                   AGE
storageblob.storage.azure.tf.crossplane.io/example   True    True     https://crossplaneexamplestoracc.blob.core.windows.net/content/sample_content   4m9s

NAME                                                      READY   SYNCED   EXTERNAL-NAME                                                    AGE
storagecontainer.storage.azure.tf.crossplane.io/example   True    True     https://crossplaneexamplestoracc.blob.core.windows.net/content   4m9s
```

Also verified resource states on Azure portal.

[contribution process]: https://git.io/fj2m9
