### PR TITLE
Ability to override ID operations

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -32,7 +32,7 @@ var (
 			base["name"] = name
 		},
 		GetNameFn: IDAsName,
-		SetIDFn:   NameAsID,
+		GetIDFn:   NameAsID,
 		OmittedFields: []string{
 			"name",
 			"name_prefix",
@@ -45,7 +45,7 @@ var (
 	IdentifierFromProvider = ExternalName{
 		SetIdentifierArgumentFn: NopSetIdentifierArgument,
 		GetNameFn:               IDAsName,
-		SetIDFn:                 NameAsID,
+		GetIDFn:                 NameAsID,
 		DisableNameInitializer:  true,
 	}
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -23,7 +23,7 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
-// Common ExternalName configurations.
+// Commonly used resource configurations.
 var (
 	// NameAsIdentifier uses "name" field in the arguments as the identifier of
 	// the resource.
@@ -62,15 +62,16 @@ var (
 
 	// NopSensitive does nothing.
 	NopSensitive = Sensitive{
-		AdditionalConnectionDetailsFn: func(_ map[string]interface{}) (map[string][]byte, error) {
-			return nil, nil
-		},
+		AdditionalConnectionDetailsFn: NopAdditionalConnectionDetails,
 	}
 )
 
+// ResourceOption allows setting optional fields of a Resource object.
+type ResourceOption func(*Resource)
+
 // DefaultResource keeps an initial default configuration for all resources of a
 // provider.
-func DefaultResource(name string, terraformSchema *schema.Resource) *Resource {
+func DefaultResource(name string, terraformSchema *schema.Resource, opts ...ResourceOption) *Resource {
 	words := strings.Split(name, "_")
 	// As group name we default to the second element if resource name
 	// has at least 3 elements, otherwise, we took the first element as
@@ -90,7 +91,7 @@ func DefaultResource(name string, terraformSchema *schema.Resource) *Resource {
 		kind = strcase.ToCamel(words[1])
 	}
 
-	return &Resource{
+	r := &Resource{
 		Name:              name,
 		TerraformResource: terraformSchema,
 		ShortGroup:        group,
@@ -100,4 +101,8 @@ func DefaultResource(name string, terraformSchema *schema.Resource) *Resource {
 		References:        map[string]Reference{},
 		Sensitive:         NopSensitive,
 	}
+	for _, f := range opts {
+		f(r)
+	}
+	return r
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -96,7 +96,6 @@ func DefaultResource(name string, terraformSchema *schema.Resource) *Resource {
 		ShortGroup:        group,
 		Kind:              kind,
 		Version:           "v1alpha1",
-		IDFieldName:       "id",
 		ExternalName:      NameAsIdentifier,
 		References:        map[string]Reference{},
 		Sensitive:         NopSensitive,

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -31,6 +31,8 @@ var (
 		SetIdentifierArgumentFn: func(base map[string]interface{}, name string) {
 			base["name"] = name
 		},
+		GetNameFn: IDAsName,
+		SetIDFn:   NameAsID,
 		OmittedFields: []string{
 			"name",
 			"name_prefix",
@@ -42,6 +44,8 @@ var (
 	// vpc-2213das instead of letting user choose a name.
 	IdentifierFromProvider = ExternalName{
 		SetIdentifierArgumentFn: NopSetIdentifierArgument,
+		GetNameFn:               IDAsName,
+		SetIDFn:                 NameAsID,
 		DisableNameInitializer:  true,
 	}
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -31,8 +31,8 @@ var (
 		SetIdentifierArgumentFn: func(base map[string]interface{}, name string) {
 			base["name"] = name
 		},
-		GetNameFn: IDAsName,
-		GetIDFn:   NameAsID,
+		GetExternalNameFn: IDAsExternalName,
+		GetIDFn:           ExternalNameAsID,
 		OmittedFields: []string{
 			"name",
 			"name_prefix",
@@ -44,8 +44,8 @@ var (
 	// vpc-2213das instead of letting user choose a name.
 	IdentifierFromProvider = ExternalName{
 		SetIdentifierArgumentFn: NopSetIdentifierArgument,
-		GetNameFn:               IDAsName,
-		GetIDFn:                 NameAsID,
+		GetExternalNameFn:       IDAsExternalName,
+		GetIDFn:                 ExternalNameAsID,
 		DisableNameInitializer:  true,
 	}
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -59,6 +59,13 @@ var (
 			"internal/controller/providerconfig",
 		},
 	}
+
+	// NopSensitive does nothing.
+	NopSensitive = Sensitive{
+		AdditionalConnectionDetailsFn: func(_ map[string]interface{}) (map[string][]byte, error) {
+			return nil, nil
+		},
+	}
 )
 
 // DefaultResource keeps an initial default configuration for all resources of a
@@ -86,13 +93,12 @@ func DefaultResource(name string, terraformSchema *schema.Resource) *Resource {
 	return &Resource{
 		Name:              name,
 		TerraformResource: terraformSchema,
-
-		ShortGroup: group,
-		Kind:       kind,
-		Version:    "v1alpha1",
-
-		IDFieldName:  "id",
-		ExternalName: NameAsIdentifier,
-		References:   map[string]Reference{},
+		ShortGroup:        group,
+		Kind:              kind,
+		Version:           "v1alpha1",
+		IDFieldName:       "id",
+		ExternalName:      NameAsIdentifier,
+		References:        map[string]Reference{},
+		Sensitive:         NopSensitive,
 	}
 }

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -19,9 +19,8 @@ package config
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
-
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestDefaultResource(t *testing.T) {
+	type args struct {
+		name string
+		sch  *schema.Resource
+		opts []ResourceOption
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   *Resource
+	}{
+		"ThreeSectionsName": {
+			reason: "It should return GVK properly for names with three sections",
+			args: args{
+				name: "aws_ec2_instance",
+			},
+			want: &Resource{
+				Name:         "aws_ec2_instance",
+				ShortGroup:   "ec2",
+				Kind:         "Instance",
+				Version:      "v1alpha1",
+				ExternalName: NameAsIdentifier,
+				References:   map[string]Reference{},
+				Sensitive:    NopSensitive,
+			},
+		},
+		"TwoSectionsName": {
+			reason: "It should return GVK properly for names with three sections",
+			args: args{
+				name: "aws_instance",
+			},
+			want: &Resource{
+				Name:         "aws_instance",
+				ShortGroup:   "aws",
+				Kind:         "Instance",
+				Version:      "v1alpha1",
+				ExternalName: NameAsIdentifier,
+				References:   map[string]Reference{},
+				Sensitive:    NopSensitive,
+			},
+		},
+	}
+
+	// TODO(muvaf): Find a way to compare function pointers.
+	ignoreUnexported := []cmp.Option{
+		cmpopts.IgnoreFields(Sensitive{}, "fieldPaths", "AdditionalConnectionDetailsFn"),
+		cmpopts.IgnoreFields(LateInitializer{}, "ignoredCanonicalFieldPaths"),
+		cmpopts.IgnoreFields(ExternalName{}, "SetIdentifierArgumentFn", "GetNameFn", "GetIDFn"),
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := DefaultResource(tc.args.name, tc.args.sch, tc.args.opts...)
+			if diff := cmp.Diff(tc.want, r, ignoreUnexported...); diff != "" {
+				t.Errorf("\n%s\nDefaultResource(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -73,7 +73,7 @@ func TestDefaultResource(t *testing.T) {
 	ignoreUnexported := []cmp.Option{
 		cmpopts.IgnoreFields(Sensitive{}, "fieldPaths", "AdditionalConnectionDetailsFn"),
 		cmpopts.IgnoreFields(LateInitializer{}, "ignoredCanonicalFieldPaths"),
-		cmpopts.IgnoreFields(ExternalName{}, "SetIdentifierArgumentFn", "GetNameFn", "GetIDFn"),
+		cmpopts.IgnoreFields(ExternalName{}, "SetIdentifierArgumentFn", "GetExternalNameFn", "GetIDFn"),
 	}
 
 	for name, tc := range cases {

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -152,13 +152,11 @@ func NewProvider(resourceMap map[string]*schema.Resource, prefix string, moduleP
 		ShortName:               fmt.Sprintf("tf%s", prefix),
 		BasePackages:            DefaultBasePackages,
 		DefaultResourceFn:       DefaultResource,
-
 		IncludeList: []string{
 			// Include all Resources
 			".+",
 		},
-		Resources: map[string]*Resource{},
-
+		Resources:             map[string]*Resource{},
 		resourceConfigurators: map[string]ResourceConfiguratorChain{},
 	}
 

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -42,7 +42,7 @@ type BasePackages struct {
 
 // DefaultResourceFn returns a default resource configuration to be used while
 // building resource configurations.
-type DefaultResourceFn func(name string, terraformResource *schema.Resource) *Resource
+type DefaultResourceFn func(name string, terraformResource *schema.Resource, opts ...ResourceOption) *Resource
 
 // Provider holds configuration for a provider to be generated with Terrajet.
 type Provider struct {

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -59,13 +59,6 @@ func NopAdditionalConnectionDetails(_ map[string]interface{}) (map[string][]byte
 // ResourceOption allows setting optional fields of a Resource object.
 type ResourceOption func(*Resource)
 
-// WithTerraformIDFieldName allows you to set IDFieldName.
-func WithTerraformIDFieldName(n string) ResourceOption {
-	return func(c *Resource) {
-		c.IDFieldName = n
-	}
-}
-
 // ExternalName contains all information that is necessary for naming operations,
 // such as removal of those fields from spec schema and calling Configure function
 // to fill attributes with information given in external name.

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 )
@@ -31,10 +33,10 @@ var NopSetIdentifierArgument SetIdentifierArgumentsFn = func(_ map[string]interf
 
 // GetIDFn returns the ID to be used in TF State file, i.e. "id" field in
 // terraform.tfstate.
-type GetIDFn func(externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error)
+type GetIDFn func(ctx context.Context, externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) (string, error)
 
 // ExternalNameAsID returns the name to be used as ID in TF State file.
-var ExternalNameAsID GetIDFn = func(externalName string, _ map[string]interface{}, _ map[string]interface{}) (string, error) {
+var ExternalNameAsID GetIDFn = func(_ context.Context, externalName string, _ map[string]interface{}, _ map[string]interface{}) (string, error) {
 	return externalName, nil
 }
 

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -22,7 +22,7 @@ import (
 
 // SetIdentifierArgumentsFn sets the name of the resource in Terraform attributes map,
 // i.e. Main HCL file.
-type SetIdentifierArgumentsFn func(base map[string]interface{}, name string)
+type SetIdentifierArgumentsFn func(base map[string]interface{}, externalName string)
 
 // NopSetIdentifierArgument does nothing. It's useful for cases where the external
 // name is calculated by provider and doesn't have any effect on spec fields.
@@ -30,18 +30,18 @@ var NopSetIdentifierArgument SetIdentifierArgumentsFn = func(_ map[string]interf
 
 // GetIDFn returns the ID to be used in TF State file, i.e. "id" field in
 // terraform.tfstate.
-type GetIDFn func(name string, parameters map[string]interface{}, providerConfig map[string]interface{}) string
+type GetIDFn func(externalName string, parameters map[string]interface{}, providerConfig map[string]interface{}) string
 
-// NameAsID returns the name to be used as ID in TF State file.
-var NameAsID GetIDFn = func(name string, _ map[string]interface{}, _ map[string]interface{}) string {
-	return name
+// ExternalNameAsID returns the name to be used as ID in TF State file.
+var ExternalNameAsID GetIDFn = func(externalName string, _ map[string]interface{}, _ map[string]interface{}) string {
+	return externalName
 }
 
-// GetNameFn returns the external name extracted from the TF State.
-type GetNameFn func(tfstate map[string]interface{}) string
+// GetExternalNameFn returns the external name extracted from the TF State.
+type GetExternalNameFn func(tfstate map[string]interface{}) string
 
-// IDAsName returns the TF State ID as external name.
-var IDAsName GetNameFn = func(tfstate map[string]interface{}) string {
+// IDAsExternalName returns the TF State ID as external name.
+var IDAsExternalName GetExternalNameFn = func(tfstate map[string]interface{}) string {
 	if id, ok := tfstate["id"].(string); ok {
 		return id
 	}
@@ -69,14 +69,14 @@ type ExternalName struct {
 	// name and assign it to that specific key for that resource type.
 	SetIdentifierArgumentFn SetIdentifierArgumentsFn
 
-	// GetNameFn returns the external name extracted from TF State. In most cases,
+	// GetExternalNameFn returns the external name extracted from TF State. In most cases,
 	// "id" field contains all the information you need. You'll need to extract
 	// the format that is decided for external name annotation to use.
 	// For example the following is an Azure resource ID:
 	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1
 	// The function should return "mygroup1" so that it can be used to set external
 	// name if it was not set already.
-	GetNameFn GetNameFn
+	GetExternalNameFn GetExternalNameFn
 
 	// GetIDFn returns the string that will be used as "id" key in TF state. In
 	// many cases, external name format is the same as "id" but when it is not

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -54,12 +54,9 @@ type AdditionalConnectionDetailsFn func(attr map[string]interface{}) (map[string
 
 // NopAdditionalConnectionDetails does nothing, when no additional connection
 // details configuration function provided.
-func NopAdditionalConnectionDetails(_ map[string]interface{}) (map[string][]byte, error) {
+var NopAdditionalConnectionDetails AdditionalConnectionDetailsFn = func(_ map[string]interface{}) (map[string][]byte, error) {
 	return nil, nil
 }
-
-// ResourceOption allows setting optional fields of a Resource object.
-type ResourceOption func(*Resource)
 
 // ExternalName contains all information that is necessary for naming operations,
 // such as removal of those fields from spec schema and calling Configure function
@@ -176,11 +173,6 @@ type Resource struct {
 
 	// TerraformResource is the Terraform representation of the resource.
 	TerraformResource *schema.Resource
-
-	// IDFieldName is the name of the ID field in Terraform state of the
-	// resource. Its default is "id" and in almost all cases, you don't need
-	// to overwrite it.
-	IDFieldName string
 
 	// ShortGroup is the short name of the API group of this CRD. The full
 	// CRD API group is calculated by adding the group suffix of the provider.

--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -146,7 +146,7 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot set observation")
 	}
 
-	lateInitedAnn, err := resource.LateInitializeAnnotations(tr, e.config.ExternalName.GetNameFn(attr), string(res.State.GetPrivateRaw()))
+	lateInitedAnn, err := resource.LateInitializeAnnotations(tr, e.config.ExternalName.GetExternalNameFn(attr), string(res.State.GetPrivateRaw()))
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot late initialize annotations")
 	}
@@ -210,7 +210,7 @@ func (e *external) Create(ctx context.Context, mg xpresource.Managed) (managed.E
 	}
 
 	// NOTE(muvaf): Only spec and metadata changes are saved after Create call.
-	_, err = resource.LateInitializeAnnotations(tr, e.config.ExternalName.GetNameFn(attr), string(res.State.GetPrivateRaw()))
+	_, err = resource.LateInitializeAnnotations(tr, e.config.ExternalName.GetExternalNameFn(attr), string(res.State.GetPrivateRaw()))
 	return managed.ExternalCreation{ConnectionDetails: conn}, errors.Wrap(err, "cannot late initialize annotations")
 }
 

--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -138,19 +138,19 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 
 	// No operation was in progress, our observation completed successfully, and
 	// we have an observation to consume.
-	attr := map[string]interface{}{}
-	if err := json.JSParser.Unmarshal(res.State.GetAttributes(), &attr); err != nil {
+	tfstate := map[string]interface{}{}
+	if err := json.JSParser.Unmarshal(res.State.GetAttributes(), &tfstate); err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot unmarshal state attributes")
 	}
-	if err := tr.SetObservation(attr); err != nil {
+	if err := tr.SetObservation(tfstate); err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot set observation")
 	}
 
-	lateInitedAnn, err := resource.LateInitializeAnnotations(tr, e.config.ExternalName.GetExternalNameFn(attr), string(res.State.GetPrivateRaw()))
+	lateInitedAnn, err := resource.LateInitializeAnnotations(tr, e.config, tfstate, string(res.State.GetPrivateRaw()))
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot late initialize annotations")
 	}
-	conn, err := resource.GetConnectionDetails(attr, tr, e.config)
+	conn, err := resource.GetConnectionDetails(tfstate, tr, e.config)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot get connection details")
 	}
@@ -199,18 +199,18 @@ func (e *external) Create(ctx context.Context, mg xpresource.Managed) (managed.E
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errApply)
 	}
-	attr := map[string]interface{}{}
-	if err := json.JSParser.Unmarshal(res.State.GetAttributes(), &attr); err != nil {
+	tfstate := map[string]interface{}{}
+	if err := json.JSParser.Unmarshal(res.State.GetAttributes(), &tfstate); err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, "cannot unmarshal state attributes")
 	}
 
-	conn, err := resource.GetConnectionDetails(attr, tr, e.config)
+	conn, err := resource.GetConnectionDetails(tfstate, tr, e.config)
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, "cannot get connection details")
 	}
 
 	// NOTE(muvaf): Only spec and metadata changes are saved after Create call.
-	_, err = resource.LateInitializeAnnotations(tr, e.config.ExternalName.GetExternalNameFn(attr), string(res.State.GetPrivateRaw()))
+	_, err = resource.LateInitializeAnnotations(tr, e.config, tfstate, string(res.State.GetPrivateRaw()))
 	return managed.ExternalCreation{ConnectionDetails: conn}, errors.Wrap(err, "cannot late initialize annotations")
 }
 

--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -146,7 +146,7 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot set observation")
 	}
 
-	lateInitedAnn, err := resource.LateInitializeAnnotations(tr, attr, string(res.State.GetPrivateRaw()))
+	lateInitedAnn, err := resource.LateInitializeAnnotations(tr, e.config.ExternalName.GetNameFn(attr), string(res.State.GetPrivateRaw()))
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot late initialize annotations")
 	}
@@ -210,7 +210,7 @@ func (e *external) Create(ctx context.Context, mg xpresource.Managed) (managed.E
 	}
 
 	// NOTE(muvaf): Only spec and metadata changes are saved after Create call.
-	_, err = resource.LateInitializeAnnotations(tr, attr, string(res.State.GetPrivateRaw()))
+	_, err = resource.LateInitializeAnnotations(tr, e.config.ExternalName.GetNameFn(attr), string(res.State.GetPrivateRaw()))
 	return managed.ExternalCreation{ConnectionDetails: conn}, errors.Wrap(err, "cannot late initialize annotations")
 }
 

--- a/pkg/controller/external_test.go
+++ b/pkg/controller/external_test.go
@@ -250,11 +250,7 @@ func TestObserve(t *testing.T) {
 		"TransitionToReady": {
 			reason: "We should mark the resource as ready if the refresh succeeds and there is no ongoing operation",
 			args: args{
-				obj: &fake.Terraformed{
-					MetadataProvider: fake.MetadataProvider{
-						IDField: "id",
-					},
-				},
+				obj: &fake.Terraformed{},
 				w: WorkspaceFns{
 					RefreshFn: func(_ context.Context) (terraform.RefreshResult, error) {
 						return terraform.RefreshResult{
@@ -277,9 +273,6 @@ func TestObserve(t *testing.T) {
 			reason: "Failure of plan should be reported",
 			args: args{
 				obj: &fake.Terraformed{
-					MetadataProvider: fake.MetadataProvider{
-						IDField: "id",
-					},
 					Managed: xpfake.Managed{
 						ConditionedStatus: xpv1.ConditionedStatus{
 							Conditions: []xpv1.Condition{xpv1.Available()},
@@ -305,9 +298,6 @@ func TestObserve(t *testing.T) {
 		"Success": {
 			args: args{
 				obj: &fake.Terraformed{
-					MetadataProvider: fake.MetadataProvider{
-						IDField: "id",
-					},
 					Managed: xpfake.Managed{
 						ConditionedStatus: xpv1.ConditionedStatus{
 							Conditions: []xpv1.Condition{xpv1.Available()},
@@ -337,7 +327,7 @@ func TestObserve(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &external{workspace: tc.w, config: &config.Resource{}}
+			e := &external{workspace: tc.w, config: config.DefaultResource("terrajet_resource", nil)}
 			_, err := e.Observe(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want error, +got error:\n%s", tc.reason, diff)

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -17,11 +17,6 @@ func (mg *{{ .CRD.Kind }}) GetTerraformResourceType() string {
 	return "{{ .Terraform.ResourceType }}"
 }
 
-// GetTerraformResourceIDField returns Terraform identifier field for this {{ .CRD.Kind }}
-func (tr *{{ .CRD.Kind }}) GetTerraformResourceIDField() string {
-	return "{{ .Terraform.IdentifierField }}"
-}
-
 // GetConnectionDetailsMapping for this {{ .CRD.Kind }}
 func (tr *{{ .CRD.Kind }}) GetConnectionDetailsMapping() map[string]string {
   {{- if .Sensitive.Fields }}

--- a/pkg/pipeline/terraformed.go
+++ b/pkg/pipeline/terraformed.go
@@ -60,15 +60,8 @@ func (tg *TerraformedGenerator) Generate(cfg *config.Resource) error {
 			"Kind":       cfg.Kind,
 		},
 		"Terraform": map[string]interface{}{
-			// TODO(hasan): This identifier is used to generate external name.
-			//  However, external-name generation is not as straightforward as
-			//  just finding out the identifier field since Terraform uses
-			//  more complex logic like combining multiple fields etc.
-			//  I'll revisit this with
-			//  https://github.com/crossplane-contrib/terrajet/issues/11
-			"IdentifierField": cfg.IDFieldName,
-			"ResourceType":    cfg.Name,
-			"SchemaVersion":   cfg.TerraformResource.SchemaVersion,
+			"ResourceType":  cfg.Name,
+			"SchemaVersion": cfg.TerraformResource.SchemaVersion,
 		},
 		"Sensitive": map[string]interface{}{
 			"Fields": cfg.Sensitive.GetFieldPaths(),

--- a/pkg/resource/fake/terraformed.go
+++ b/pkg/resource/fake/terraformed.go
@@ -65,7 +65,6 @@ func (p *Parameterizable) SetParameters(data map[string]interface{}) error {
 // MetadataProvider is mock MetadataProvider.
 type MetadataProvider struct {
 	Type                     string
-	IDField                  string
 	SchemaVersion            int
 	ConnectionDetailsMapping map[string]string
 }
@@ -73,11 +72,6 @@ type MetadataProvider struct {
 // GetTerraformResourceType is a mock.
 func (mp *MetadataProvider) GetTerraformResourceType() string {
 	return mp.Type
-}
-
-// GetTerraformResourceIDField is a mock.
-func (mp *MetadataProvider) GetTerraformResourceIDField() string {
-	return mp.IDField
 }
 
 // GetTerraformSchemaVersion is a mock.

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -37,7 +37,6 @@ type Parameterizable interface {
 // resource.
 type MetadataProvider interface {
 	GetTerraformResourceType() string
-	GetTerraformResourceIDField() string
 	GetTerraformSchemaVersion() int
 	GetConnectionDetailsMapping() map[string]string
 }

--- a/pkg/resource/lateinit.go
+++ b/pkg/resource/lateinit.go
@@ -53,7 +53,7 @@ type GenericLateInitializer struct {
 }
 
 // LateInitializeAnnotations late initializes annotations of the resource
-func LateInitializeAnnotations(tr Terraformed, attr map[string]interface{}, privateRaw string) (bool, error) {
+func LateInitializeAnnotations(tr Terraformed, id string, privateRaw string) (bool, error) {
 	if tr.GetAnnotations()[AnnotationKeyPrivateRawAttribute] == privateRaw &&
 		xpmeta.GetExternalName(tr) != "" {
 		return false, nil
@@ -64,20 +64,7 @@ func LateInitializeAnnotations(tr Terraformed, attr map[string]interface{}, priv
 	if xpmeta.GetExternalName(tr) != "" {
 		return true, nil
 	}
-
-	// Terraform stores id for the external resource as an attribute in the
-	// resource state. Key for the attribute holding external identifier is
-	// resource specific. We rely on GetTerraformResourceIDField() function
-	// to find out that key.
-	id, exists := attr[tr.GetTerraformResourceIDField()]
-	if !exists {
-		return false, errors.Errorf("no value for id field: %s", tr.GetTerraformResourceIDField())
-	}
-	extID, ok := id.(string)
-	if !ok {
-		return false, errors.Errorf("value of id field is not a string: %v", id)
-	}
-	xpmeta.SetExternalName(tr, extID)
+	xpmeta.SetExternalName(tr, id)
 	return true, nil
 }
 

--- a/pkg/resource/lateinit.go
+++ b/pkg/resource/lateinit.go
@@ -54,7 +54,7 @@ type GenericLateInitializer struct {
 }
 
 // LateInitializeAnnotations late initializes annotations of the resource
-func LateInitializeAnnotations(tr metav1.Object, id string, privateRaw string) (bool, error) {
+func LateInitializeAnnotations(tr metav1.Object, name string, privateRaw string) (bool, error) {
 	if tr.GetAnnotations()[AnnotationKeyPrivateRawAttribute] == privateRaw &&
 		xpmeta.GetExternalName(tr) != "" {
 		return false, nil
@@ -65,7 +65,7 @@ func LateInitializeAnnotations(tr metav1.Object, id string, privateRaw string) (
 	if xpmeta.GetExternalName(tr) != "" {
 		return true, nil
 	}
-	xpmeta.SetExternalName(tr, id)
+	xpmeta.SetExternalName(tr, name)
 	return true, nil
 }
 

--- a/pkg/resource/lateinit.go
+++ b/pkg/resource/lateinit.go
@@ -25,6 +25,8 @@ import (
 	xpmeta "github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/crossplane-contrib/terrajet/pkg/config"
 )
 
 const (
@@ -54,7 +56,7 @@ type GenericLateInitializer struct {
 }
 
 // LateInitializeAnnotations late initializes annotations of the resource
-func LateInitializeAnnotations(tr metav1.Object, name string, privateRaw string) (bool, error) {
+func LateInitializeAnnotations(tr metav1.Object, cfg *config.Resource, tfstate map[string]interface{}, privateRaw string) (bool, error) {
 	if tr.GetAnnotations()[AnnotationKeyPrivateRawAttribute] == privateRaw &&
 		xpmeta.GetExternalName(tr) != "" {
 		return false, nil
@@ -64,6 +66,10 @@ func LateInitializeAnnotations(tr metav1.Object, name string, privateRaw string)
 	})
 	if xpmeta.GetExternalName(tr) != "" {
 		return true, nil
+	}
+	name, err := cfg.ExternalName.GetExternalNameFn(tfstate)
+	if err != nil {
+		return false, errors.Wrap(err, "cannot get external name")
 	}
 	xpmeta.SetExternalName(tr, name)
 	return true, nil

--- a/pkg/resource/lateinit.go
+++ b/pkg/resource/lateinit.go
@@ -24,6 +24,7 @@ import (
 
 	xpmeta "github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -53,7 +54,7 @@ type GenericLateInitializer struct {
 }
 
 // LateInitializeAnnotations late initializes annotations of the resource
-func LateInitializeAnnotations(tr Terraformed, id string, privateRaw string) (bool, error) {
+func LateInitializeAnnotations(tr metav1.Object, id string, privateRaw string) (bool, error) {
 	if tr.GetAnnotations()[AnnotationKeyPrivateRawAttribute] == privateRaw &&
 		xpmeta.GetExternalName(tr) != "" {
 		return false, nil

--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -43,6 +43,9 @@ const (
 	// overridden by any custom connection key configured which would break
 	// our ability to build tfstate back.
 	prefixAttribute = "attribute."
+
+	errGetAdditionalConnectionDetails = "cannot get additional connection details"
+	errFmtCannotOverrideExistingKey   = "overriding a reserved connection key (%q) is not allowed"
 )
 
 var reEndsWithIndex *regexp.Regexp
@@ -65,25 +68,16 @@ type SecretClient interface {
 // GetConnectionDetails returns connection details including the sensitive
 // Terraform attributes and additions connection details configured.
 func GetConnectionDetails(attr map[string]interface{}, tr Terraformed, cfg *config.Resource) (managed.ConnectionDetails, error) {
-	conn, err := GetSensitiveAttributes(attr, tr.GetConnectionDetailsMapping(), tr.GetTerraformResourceIDField())
+	conn, err := GetSensitiveAttributes(attr, tr.GetConnectionDetailsMapping())
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get connection details")
 	}
 
-	var custom map[string][]byte
-	// TODO(turkenh): Once we have automatic defaulting, remove this if check.
-	if cfg.Sensitive.AdditionalConnectionDetailsFn != nil {
-		if custom, err = cfg.Sensitive.AdditionalConnectionDetailsFn(attr); err != nil {
-			return nil, errors.Wrap(err, "cannot get custom connection keys")
-		}
+	add, err := cfg.Sensitive.AdditionalConnectionDetailsFn(attr)
+	if err != nil {
+		return nil, errors.Wrap(err, errGetAdditionalConnectionDetails)
 	}
-
-	if conn == nil {
-		// if there is no sensitive attributes but still some custom connection
-		// keys, e.g. endpoint
-		return custom, nil
-	}
-	for k, v := range custom {
+	for k, v := range add {
 		if _, ok := conn[k]; ok {
 			// We return error if a custom key tries to override an existing
 			// connection key. This is because we use connection keys to rebuild
@@ -93,23 +87,35 @@ func GetConnectionDetails(attr map[string]interface{}, tr Terraformed, cfg *conf
 			// state sensitive keys and connection keys starting with this
 			// prefix are reserved and should not be used as a custom connection
 			// key.
-			return nil, errors.Errorf("custom connection keys cannot start with %q, overriding reserved connection key (%q) is not allowed", k, prefixAttribute)
+			return nil, errors.Errorf(errFmtCannotOverrideExistingKey, k)
+		}
+		if conn == nil {
+			conn = map[string][]byte{}
 		}
 		conn[k] = v
 	}
+
+	// NOTE(muvaf): Having ID in the connection details is not really a must but
+	// just a nice-to-have, hence we don't handle cases where the ID is given
+	// in a field other than "id". cfg.ExternalName.GetNameFn wouldn't really
+	// help because we need the raw ID.
+	if id, ok := attr["id"]; conn != nil && ok {
+		conn[fmt.Sprintf("%sid", prefixAttribute)] = []byte(id.(string))
+	}
+
 	return conn, nil
 }
 
 // GetSensitiveAttributes returns strings matching provided field paths in the
 // input data.
 // See the unit tests for examples.
-func GetSensitiveAttributes(from map[string]interface{}, mapping map[string]string, idField string) (map[string][]byte, error) {
+func GetSensitiveAttributes(from map[string]interface{}, mapping map[string]string) (map[string][]byte, error) {
 	if len(mapping) == 0 {
 		return nil, nil
 	}
+	paved := fieldpath.Pave(from)
 	vals := make(map[string][]byte)
 	for tf := range mapping {
-		paved := fieldpath.Pave(from)
 		fieldPaths, err := paved.ExpandWildcards(tf)
 		if err != nil {
 			return nil, errors.Wrap(err, errCannotExpandWildcards)
@@ -131,11 +137,6 @@ func GetSensitiveAttributes(from map[string]interface{}, mapping map[string]stri
 			}
 			vals[fmt.Sprintf("%s%s", prefixAttribute, k)] = []byte(v)
 		}
-	}
-
-	id, ok := from[idField].(string)
-	if ok {
-		vals[fmt.Sprintf("%s%s", prefixAttribute, idField)] = []byte(id)
 	}
 	return vals, nil
 }

--- a/pkg/resource/sensitive_test.go
+++ b/pkg/resource/sensitive_test.go
@@ -20,12 +20,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
-
-	"github.com/crossplane-contrib/terrajet/pkg/config"
-	"github.com/crossplane-contrib/terrajet/pkg/resource/fake"
-
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -33,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/crossplane-contrib/terrajet/pkg/config"
+	"github.com/crossplane-contrib/terrajet/pkg/resource/fake"
 	"github.com/crossplane-contrib/terrajet/pkg/resource/fake/mocks"
 	"github.com/crossplane-contrib/terrajet/pkg/resource/json"
 )

--- a/pkg/resource/sensitive_test.go
+++ b/pkg/resource/sensitive_test.go
@@ -112,14 +112,12 @@ func TestGetConnectionDetails(t *testing.T) {
 				},
 				cfg: config.DefaultResource("terrajet_resource", nil),
 				data: map[string]interface{}{
-					"id":               "secret-id",
 					"top_level_secret": "sensitive-data-top-level-secret",
 				},
 			},
 			want: want{
 				out: map[string][]byte{
 					"attribute.top_level_secret": []byte("sensitive-data-top-level-secret"),
-					"attribute.id":               []byte("secret-id"),
 				},
 			},
 		},
@@ -136,14 +134,12 @@ func TestGetConnectionDetails(t *testing.T) {
 					},
 				},
 				data: map[string]interface{}{
-					"id":               "secret-id",
 					"top_level_secret": "sensitive-data-top-level-secret",
 				},
 			},
 			want: want{
 				out: map[string][]byte{
 					"top_level_secret_custom": []byte("sensitive-data-top-level-secret"),
-					"attribute.id":            []byte("secret-id"),
 				},
 			},
 		},
@@ -235,9 +231,6 @@ func TestGetSensitiveAttributes(t *testing.T) {
 			args: args{
 				paths: map[string]string{"missing_field": ""},
 				data:  testInput,
-			},
-			want: want{
-				out: map[string][]byte{},
 			},
 		},
 		"SingleGettingNumber": {
@@ -345,9 +338,6 @@ func TestGetSensitiveAttributes(t *testing.T) {
 			args: args{
 				paths: map[string]string{"top_level_secret": ""},
 				data:  nil,
-			},
-			want: want{
-				out: map[string][]byte{},
 			},
 		},
 	}

--- a/pkg/resource/sensitive_test.go
+++ b/pkg/resource/sensitive_test.go
@@ -20,6 +20,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+
+	"github.com/crossplane-contrib/terrajet/pkg/config"
+	"github.com/crossplane-contrib/terrajet/pkg/resource/fake"
+
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/golang/mock/gomock"
@@ -32,7 +37,8 @@ import (
 	"github.com/crossplane-contrib/terrajet/pkg/resource/json"
 )
 
-var testData = []byte(`
+var (
+	testData = []byte(`
 {
   "top_level_secret": "sensitive-data-top-level-secret",
   "top_config_secretmap": {
@@ -70,6 +76,134 @@ var testData = []byte(`
   ]
 }
 `)
+	errBoom = errors.New("boom")
+)
+
+func TestGetConnectionDetails(t *testing.T) {
+	testInput := map[string]interface{}{}
+	if err := json.JSParser.Unmarshal(testData, &testInput); err != nil {
+		t.Fatalf("cannot unmarshall test data: %v", err)
+	}
+	type args struct {
+		tr   Terraformed
+		cfg  *config.Resource
+		data map[string]interface{}
+	}
+	type want struct {
+		out managed.ConnectionDetails
+		err error
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"NoConnectionDetails": {
+			args: args{
+				tr:  &fake.Terraformed{},
+				cfg: config.DefaultResource("terrajet_resource", nil),
+			},
+		},
+		"OnlyDefaultConnectionDetails": {
+			args: args{
+				tr: &fake.Terraformed{
+					MetadataProvider: fake.MetadataProvider{
+						ConnectionDetailsMapping: map[string]string{
+							"top_level_secret": "some.field",
+						},
+					},
+				},
+				cfg: config.DefaultResource("terrajet_resource", nil),
+				data: map[string]interface{}{
+					"id":               "secret-id",
+					"top_level_secret": "sensitive-data-top-level-secret",
+				},
+			},
+			want: want{
+				out: map[string][]byte{
+					"attribute.top_level_secret": []byte("sensitive-data-top-level-secret"),
+					"attribute.id":               []byte("secret-id"),
+				},
+			},
+		},
+		"OnlyAdditionalConnectionDetails": {
+			args: args{
+				tr: &fake.Terraformed{},
+				cfg: &config.Resource{
+					Sensitive: config.Sensitive{
+						AdditionalConnectionDetailsFn: func(attr map[string]interface{}) (map[string][]byte, error) {
+							return map[string][]byte{
+								"top_level_secret_custom": []byte(attr["top_level_secret"].(string)),
+							}, nil
+						},
+					},
+				},
+				data: map[string]interface{}{
+					"id":               "secret-id",
+					"top_level_secret": "sensitive-data-top-level-secret",
+				},
+			},
+			want: want{
+				out: map[string][]byte{
+					"top_level_secret_custom": []byte("sensitive-data-top-level-secret"),
+					"attribute.id":            []byte("secret-id"),
+				},
+			},
+		},
+		"AdditionalConnectionDetailsFailed": {
+			args: args{
+				tr: &fake.Terraformed{},
+				cfg: &config.Resource{
+					Sensitive: config.Sensitive{
+						AdditionalConnectionDetailsFn: func(attr map[string]interface{}) (map[string][]byte, error) {
+							return nil, errBoom
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errGetAdditionalConnectionDetails),
+			},
+		},
+		"CannotOverrideExistingKey": {
+			args: args{
+				tr: &fake.Terraformed{
+					MetadataProvider: fake.MetadataProvider{
+						ConnectionDetailsMapping: map[string]string{
+							"top_level_secret": "some.field",
+						},
+					},
+				},
+				cfg: &config.Resource{
+					Sensitive: config.Sensitive{
+						AdditionalConnectionDetailsFn: func(attr map[string]interface{}) (map[string][]byte, error) {
+							return map[string][]byte{
+								"attribute.top_level_secret": []byte(""),
+							}, nil
+						},
+					},
+				},
+				data: map[string]interface{}{
+					"id":               "secret-id",
+					"top_level_secret": "sensitive-data-top-level-secret",
+				},
+			},
+			want: want{
+				err: errors.Errorf(errFmtCannotOverrideExistingKey, "attribute.top_level_secret"),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, gotErr := GetConnectionDetails(tc.data, tc.tr, tc.cfg)
+			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
+				t.Fatalf("GetConnectionDetails(...): -want error, +got error: %s", diff)
+			}
+			if diff := cmp.Diff(tc.want.out, got); diff != "" {
+				t.Errorf("\nGetConnectionDetails(...): -want error, +got error:\n%s", diff)
+			}
+		})
+	}
+}
 
 func TestGetSensitiveAttributes(t *testing.T) {
 	testInput := map[string]interface{}{}
@@ -96,21 +230,6 @@ func TestGetSensitiveAttributes(t *testing.T) {
 			want: want{
 				out: map[string][]byte{
 					prefixAttribute + "top_level_secret": []byte("sensitive-data-top-level-secret"),
-				},
-			},
-		},
-		"AddsIDIfExists": {
-			args: args{
-				paths: map[string]string{"top_level_secret": ""},
-				data: map[string]interface{}{
-					"id":               "secret-id",
-					"top_level_secret": "sensitive-data-top-level-secret",
-				},
-			},
-			want: want{
-				out: map[string][]byte{
-					prefixAttribute + "top_level_secret": []byte("sensitive-data-top-level-secret"),
-					prefixAttribute + "id":               []byte("secret-id"),
 				},
 			},
 		},
@@ -236,12 +355,12 @@ func TestGetSensitiveAttributes(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, gotErr := GetSensitiveAttributes(tc.data, tc.paths, "id")
+			got, gotErr := GetSensitiveAttributes(tc.data, tc.paths)
 			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
 				t.Fatalf("GetFields(...): -want error, +got error: %s", diff)
 			}
 			if diff := cmp.Diff(tc.want.out, got); diff != "" {
-				t.Errorf("GetFields(...) out = %v, want %v", got, tc.want.out)
+				t.Errorf("\nGetSensitiveAttributes(...): -want error, +got error:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/terraform/files.go
+++ b/pkg/terraform/files.go
@@ -101,7 +101,7 @@ func (fp *FileProducer) WriteTFState() error {
 	for k, v := range fp.observation {
 		base[k] = v
 	}
-	fp.Config.ExternalName.SetIDFn(meta.GetExternalName(fp.Resource), fp.parameters, base)
+	base["id"] = fp.Config.ExternalName.GetIDFn(meta.GetExternalName(fp.Resource), fp.parameters, fp.Setup.Configuration)
 	attr, err := json.JSParser.Marshal(base)
 	if err != nil {
 		return errors.Wrap(err, "cannot marshal produced state attributes")

--- a/pkg/terraform/files.go
+++ b/pkg/terraform/files.go
@@ -91,7 +91,7 @@ type FileProducer struct {
 
 // WriteTFState writes the Terraform state that should exist in the filesystem to
 // start any Terraform operation.
-func (fp *FileProducer) WriteTFState() error {
+func (fp *FileProducer) WriteTFState(ctx context.Context) error {
 	base := make(map[string]interface{})
 	// NOTE(muvaf): Since we try to produce the current state, observation
 	// takes precedence over parameters.
@@ -101,7 +101,7 @@ func (fp *FileProducer) WriteTFState() error {
 	for k, v := range fp.observation {
 		base[k] = v
 	}
-	id, err := fp.Config.ExternalName.GetIDFn(meta.GetExternalName(fp.Resource), fp.parameters, fp.Setup.Configuration)
+	id, err := fp.Config.ExternalName.GetIDFn(ctx, meta.GetExternalName(fp.Resource), fp.parameters, fp.Setup.Configuration)
 	if err != nil {
 		return errors.Wrap(err, "cannot get id")
 	}

--- a/pkg/terraform/files.go
+++ b/pkg/terraform/files.go
@@ -61,10 +61,7 @@ func NewFileProducer(ctx context.Context, client resource.SecretClient, dir stri
 	if err = resource.GetSensitiveParameters(ctx, client, tr, params, tr.GetConnectionDetailsMapping()); err != nil {
 		return nil, errors.Wrap(err, "cannot get sensitive parameters")
 	}
-	// TODO(muvaf): Once we have automatic defaulting, remove this if check.
-	if fp.Config.ExternalName.SetIdentifierArgumentFn != nil {
-		fp.Config.ExternalName.SetIdentifierArgumentFn(params, meta.GetExternalName(tr))
-	}
+	fp.Config.ExternalName.SetIdentifierArgumentFn(params, meta.GetExternalName(tr))
 	fp.parameters = params
 
 	obs, err := tr.GetObservation()
@@ -104,7 +101,7 @@ func (fp *FileProducer) WriteTFState() error {
 	for k, v := range fp.observation {
 		base[k] = v
 	}
-	base["id"] = meta.GetExternalName(fp.Resource)
+	fp.Config.ExternalName.SetIDFn(meta.GetExternalName(fp.Resource), fp.parameters, base)
 	attr, err := json.JSParser.Marshal(base)
 	if err != nil {
 		return errors.Wrap(err, "cannot marshal produced state attributes")

--- a/pkg/terraform/files.go
+++ b/pkg/terraform/files.go
@@ -101,7 +101,11 @@ func (fp *FileProducer) WriteTFState() error {
 	for k, v := range fp.observation {
 		base[k] = v
 	}
-	base["id"] = fp.Config.ExternalName.GetIDFn(meta.GetExternalName(fp.Resource), fp.parameters, fp.Setup.Configuration)
+	id, err := fp.Config.ExternalName.GetIDFn(meta.GetExternalName(fp.Resource), fp.parameters, fp.Setup.Configuration)
+	if err != nil {
+		return errors.Wrap(err, "cannot get id")
+	}
+	base["id"] = id
 	attr, err := json.JSParser.Marshal(base)
 	if err != nil {
 		return errors.Wrap(err, "cannot marshal produced state attributes")

--- a/pkg/terraform/files_test.go
+++ b/pkg/terraform/files_test.go
@@ -77,11 +77,12 @@ func TestWriteTFState(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			fp, err := NewFileProducer(context.TODO(), nil, dir, tc.args.tr, tc.args.s, config.DefaultResource("terrajet_resource", nil), WithFileSystem(fs))
+			ctx := context.TODO()
+			fp, err := NewFileProducer(ctx, nil, dir, tc.args.tr, tc.args.s, config.DefaultResource("terrajet_resource", nil), WithFileSystem(fs))
 			if err != nil {
 				t.Errorf("cannot initialize a file producer: %s", err.Error())
 			}
-			err = fp.WriteTFState()
+			err = fp.WriteTFState(ctx)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nWriteTFState(...): -want error, +got error:\n%s", tc.reason, diff)
 			}

--- a/pkg/terraform/files_test.go
+++ b/pkg/terraform/files_test.go
@@ -70,14 +70,14 @@ func TestWriteTFState(t *testing.T) {
 				}},
 			}},
 			want: want{
-				tfstate: `{"version":4,"terraform_version":"","serial":1,"lineage":"","outputs":null,"resources":[{"mode":"managed","type":"","name":"","provider":"provider[\"registry.terraform.io/\"]","instances":[{"schema_version":0,"attributes":{"id":"some-id","obs":"obsval","param":"paramval"},"private":"cHJpdmF0ZXJhdw=="}]}]}`,
+				tfstate: `{"version":4,"terraform_version":"","serial":1,"lineage":"","outputs":null,"resources":[{"mode":"managed","type":"","name":"","provider":"provider[\"registry.terraform.io/\"]","instances":[{"schema_version":0,"attributes":{"id":"some-id","name":"some-id","obs":"obsval","param":"paramval"},"private":"cHJpdmF0ZXJhdw=="}]}]}`,
 			},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			fp, err := NewFileProducer(context.TODO(), nil, dir, tc.args.tr, tc.args.s, &config.Resource{}, WithFileSystem(fs))
+			fp, err := NewFileProducer(context.TODO(), nil, dir, tc.args.tr, tc.args.s, config.DefaultResource("terrajet_resource", nil), WithFileSystem(fs))
 			if err != nil {
 				t.Errorf("cannot initialize a file producer: %s", err.Error())
 			}
@@ -136,14 +136,14 @@ func TestWriteMainTF(t *testing.T) {
 				},
 			},
 			want: want{
-				maintf: `{"provider":{"provider-test":null},"resource":{"":{"":{"lifecycle":{"prevent_destroy":true},"param":"paramval"}}},"terraform":{"required_providers":{"provider-test":{"source":"hashicorp/provider-test","version":"1.2.3"}}}}`,
+				maintf: `{"provider":{"provider-test":null},"resource":{"":{"":{"lifecycle":{"prevent_destroy":true},"name":"some-id","param":"paramval"}}},"terraform":{"required_providers":{"provider-test":{"source":"hashicorp/provider-test","version":"1.2.3"}}}}`,
 			},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			fp, err := NewFileProducer(context.TODO(), nil, dir, tc.args.tr, tc.args.s, &config.Resource{}, WithFileSystem(fs))
+			fp, err := NewFileProducer(context.TODO(), nil, dir, tc.args.tr, tc.args.s, config.DefaultResource("terrajet_resource", nil), WithFileSystem(fs))
 			if err != nil {
 				t.Errorf("cannot initialize a file producer: %s", err.Error())
 			}

--- a/pkg/terraform/store.go
+++ b/pkg/terraform/store.go
@@ -110,7 +110,7 @@ func (ws *WorkspaceStore) Workspace(ctx context.Context, c resource.SecretClient
 		return nil, errors.Wrap(err, "cannot stat terraform.tfstate file")
 	}
 	if os.IsNotExist(err) {
-		if err := fp.WriteTFState(); err != nil {
+		if err := fp.WriteTFState(ctx); err != nil {
 			return nil, errors.Wrap(err, "cannot reproduce tfstate file")
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Allows users to override the default `TF State ID -> External Name` and `External Name -> TF State ID` flows. Note that we already have `SetIdentifierArgumentFn` endpoint but that's for overriding `External Name -> Main TF File`. Details about why we're doing this are in the issue.

Depends on https://github.com/crossplane-contrib/terrajet/pull/128 . See the last 3 commits for actual diff.

Fixes https://github.com/crossplane-contrib/terrajet/issues/119
Fixes https://github.com/crossplane-contrib/terrajet/issues/104

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests and see https://github.com/crossplane-contrib/provider-tf-azure/pull/84
