### PR TITLE
pipeline: put underscore between CRD kind and GVK suffix

### DIFF
--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -25,12 +25,12 @@ import (
 
 // Setup adds a controller that reconciles {{ .CRD.Kind }} managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
-	name := managed.ControllerName({{ .TypePackageAlias }}{{ .CRD.Kind }}GroupVersionKind.String())
+	name := managed.ControllerName({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind.String())
 	r := managed.NewReconciler(mgr,
-		xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}GroupVersionKind),
+		xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["{{ .ResourceType }}"],
 			{{- if .UseAsync }}
-			tjcontroller.WithCallbackProvider(tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}GroupVersionKind))),
+			tjcontroller.WithCallbackProvider(tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind))),
 			{{- end}}
 		)),
 		managed.WithLogger(l.WithValues("controller", name)),

--- a/pkg/pipeline/templates/crd_types.go.tmpl
+++ b/pkg/pipeline/templates/crd_types.go.tmpl
@@ -52,10 +52,10 @@ type {{ .CRD.Kind }}List struct {
 
 // Repository type metadata.
 var (
-	{{ .CRD.Kind }}Kind             = "{{ .CRD.Kind }}"
-	{{ .CRD.Kind }}GroupKind        = schema.GroupKind{Group: Group, Kind: {{ .CRD.Kind }}Kind}.String()
-	{{ .CRD.Kind }}KindAPIVersion   = {{ .CRD.Kind }}Kind + "." + GroupVersion.String()
-	{{ .CRD.Kind }}GroupVersionKind = GroupVersion.WithKind({{ .CRD.Kind }}Kind)
+	{{ .CRD.Kind }}_Kind             = "{{ .CRD.Kind }}"
+	{{ .CRD.Kind }}_GroupKind        = schema.GroupKind{Group: Group, Kind: {{ .CRD.Kind }}_Kind}.String()
+	{{ .CRD.Kind }}_KindAPIVersion   = {{ .CRD.Kind }}_Kind + "." + GroupVersion.String()
+	{{ .CRD.Kind }}_GroupVersionKind = GroupVersion.WithKind({{ .CRD.Kind }}_Kind)
 )
 
 func init() {


### PR DESCRIPTION
### Description of your changes

When there are two types like `Network` and `NetworkGroup`, then `NetworkGroupKind` of `Network` collides with `NetworkGroupKind` of `NetworkGroup`. This PR makes it so that they are generated as `NetworkGroup_Kind` and `Network_GroupKind`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually with provider-tf-aws.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
