### PR TITLE
Extract Terraform error messages from JSON logs

### DIFF
--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"testing"
 
-	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
-	xpfake "github.com/crossplane/crossplane-runtime/pkg/resource/fake"
-	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
+	xpfake "github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane-contrib/terrajet/pkg/resource"
 	"github.com/crossplane-contrib/terrajet/pkg/resource/fake"
@@ -56,7 +57,7 @@ func TestAPICallbacks_Apply(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil),
 						MockStatusUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 							got := obj.(resource.Terraformed).GetCondition(resource.TypeAsyncOperation)
-							if diff := cmp.Diff(resource.AsyncOperationCondition(tjerrors.NewApplyFailed(errBoom.Error())), got); diff != "" {
+							if diff := cmp.Diff(resource.AsyncOperationCondition(tjerrors.WrapApplyFailed(errBoom, nil)), got); diff != "" {
 								t.Errorf("\nApply(...): -want error, +got error:\n%s", diff)
 							}
 							return nil
@@ -64,7 +65,7 @@ func TestAPICallbacks_Apply(t *testing.T) {
 					},
 					Scheme: xpfake.SchemeWith(&fake.Terraformed{}),
 				},
-				err: tjerrors.NewApplyFailed(errBoom.Error()),
+				err: tjerrors.WrapApplyFailed(errBoom, nil),
 			},
 		},
 		"ApplyOperationSucceeded": {
@@ -138,7 +139,7 @@ func TestAPICallbacks_Destroy(t *testing.T) {
 						MockGet: test.NewMockGetFn(nil),
 						MockStatusUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 							got := obj.(resource.Terraformed).GetCondition(resource.TypeAsyncOperation)
-							if diff := cmp.Diff(resource.AsyncOperationCondition(tjerrors.NewDestroyFailed(errBoom.Error())), got); diff != "" {
+							if diff := cmp.Diff(resource.AsyncOperationCondition(tjerrors.WrapDestroyFailed(errBoom, nil)), got); diff != "" {
 								t.Errorf("\nApply(...): -want error, +got error:\n%s", diff)
 							}
 							return nil
@@ -146,7 +147,7 @@ func TestAPICallbacks_Destroy(t *testing.T) {
 					},
 					Scheme: xpfake.SchemeWith(&fake.Terraformed{}),
 				},
-				err: tjerrors.NewDestroyFailed(errBoom.Error()),
+				err: tjerrors.WrapDestroyFailed(errBoom, nil),
 			},
 		},
 		"DestroyOperationSucceeded": {

--- a/pkg/terraform/errors/errors.go
+++ b/pkg/terraform/errors/errors.go
@@ -16,40 +16,156 @@ limitations under the License.
 
 package errors
 
+import (
+	"fmt"
+	"strings"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+const (
+	levelError = "error"
+)
+
+type tfError struct {
+	logs    []byte
+	tfLogs  []*TerraformLog
+	cause   error
+	message string
+}
+
 type applyFailed struct {
-	log string
+	*tfError
 }
 
-func (a *applyFailed) Error() string {
-	return a.log
+// TerraformLog represents relevant fields of a Terraform CLI JSON-formatted log line
+type TerraformLog struct {
+	Level      string        `json:"@level"`
+	Message    string        `json:"@message"`
+	Diagnostic LogDiagnostic `json:"diagnostic"`
 }
 
-// NewApplyFailed returns a new apply failure error with given logs.
-func NewApplyFailed(log string) error {
-	return &applyFailed{log: log}
+// LogDiagnostic represents relevant fields of a Terraform CLI JSON-formatted
+// log line diagnostic info
+type LogDiagnostic struct {
+	Severity string `json:"severity"`
+	Summary  string `json:"summary"`
+	Detail   string `json:"detail"`
+}
+
+func (t *tfError) Error() string {
+	if t == nil {
+		return ""
+	}
+
+	messages := make([]string, 0, len(t.tfLogs))
+	for _, l := range t.tfLogs {
+		// only use error logs
+		if l == nil || l.Level != levelError {
+			continue
+		}
+		m := l.Message
+		if l.Diagnostic.Severity == levelError && l.Diagnostic.Summary != "" {
+			m = fmt.Sprintf("%s: %s", l.Diagnostic.Summary, l.Diagnostic.Detail)
+		}
+		messages = append(messages, m)
+	}
+	return fmt.Sprintf("%s: %s", t.message, strings.Join(messages, "\n"))
+}
+
+func (t *tfError) Unwrap() error {
+	if t == nil {
+		return nil
+	}
+	return t.cause
+}
+
+func newTFError(message string, cause error, logs []byte) (string, *tfError) {
+	tfError := &tfError{
+		logs:    logs,
+		cause:   cause,
+		message: message,
+	}
+
+	tfLogs, err := parseTerraformLogs(logs)
+	if err != nil {
+		return err.Error(), tfError
+	}
+	tfError.tfLogs = tfLogs
+	return "", tfError
+}
+
+func parseTerraformLogs(logs []byte) ([]*TerraformLog, error) {
+	logLines := strings.Split(string(logs), "\n")
+	tfLogs := make([]*TerraformLog, 0, len(logLines))
+	for _, l := range logLines {
+		log := &TerraformLog{}
+		l := strings.TrimSpace(l)
+		if l == "" {
+			continue
+		}
+		if err := jsoniter.ConfigCompatibleWithStandardLibrary.UnmarshalFromString(l, log); err != nil {
+			return nil, err
+		}
+		tfLogs = append(tfLogs, log)
+	}
+	return tfLogs, nil
+}
+
+// WrapTFError returns a new Terraform CLI failure error with given logs.
+func WrapTFError(message string, cause error, logs []byte) error {
+	if cause == nil {
+		return nil
+	}
+
+	parseError, tfError := newTFError(message, cause, logs)
+	if parseError == "" {
+		return tfError
+	}
+	return errors.WithMessage(tfError, parseError)
+}
+
+// WrapApplyFailed returns a new apply failure error with given logs.
+func WrapApplyFailed(cause error, logs []byte) error {
+	if cause == nil {
+		return nil
+	}
+
+	parseError, tfError := newTFError("apply failed", cause, logs)
+	result := &applyFailed{tfError: tfError}
+	if parseError == "" {
+		return result
+	}
+	return errors.WithMessage(result, parseError)
 }
 
 // IsApplyFailed returns whether error is due to failure of an apply operation.
 func IsApplyFailed(err error) bool {
-	_, ok := err.(*applyFailed)
-	return ok
+	r := &applyFailed{}
+	return errors.As(err, &r)
 }
 
 type destroyFailed struct {
-	log string
+	*tfError
 }
 
-func (a *destroyFailed) Error() string {
-	return a.log
-}
+// WrapDestroyFailed returns a new destroy failure error with given logs.
+func WrapDestroyFailed(cause error, logs []byte) error {
+	if cause == nil {
+		return nil
+	}
 
-// NewDestroyFailed returns a new destroy failure error with given logs.
-func NewDestroyFailed(log string) error {
-	return &destroyFailed{log: log}
+	parseError, tfError := newTFError("destroy failed", cause, logs)
+	result := &destroyFailed{tfError: tfError}
+	if parseError == "" {
+		return result
+	}
+	return errors.WithMessage(result, parseError)
 }
 
 // IsDestroyFailed returns whether error is due to failure of a destroy operation.
 func IsDestroyFailed(err error) bool {
-	_, ok := err.(*destroyFailed)
-	return ok
+	r := &destroyFailed{}
+	return errors.As(err, &r)
 }

--- a/pkg/terraform/errors/errors_test.go
+++ b/pkg/terraform/errors/errors_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+)
+
+var (
+	errorLog = []byte(`{"@level":"info","@message":"Terraform 1.0.3","@module":"terraform.ui","@timestamp":"2021-11-14T23:23:14.009380+03:00","terraform":"1.0.3","type":"version","ui":"0.1.0"}
+{"@level":"error","@message":"Error: Missing required argument","@module":"terraform.ui","@timestamp":"2021-11-14T23:23:14.576254+03:00","diagnostic":{"severity":"error","summary":"Missing required argument","detail":"The argument \"location\" is required, but no definition was found.","range":{"filename":"main.tf.json","start":{"line":24,"column":7,"byte":568},"end":{"line":24,"column":8,"byte":569}},"snippet":{"context":"resource.azurerm_resource_group.example","code":"      }","start_line":24,"highlight_start_offset":6,"highlight_end_offset":7,"values":[]}},"type":"diagnostic"}
+{"@level":"error","@message":"Error: Missing required argument","@module":"terraform.ui","@timestamp":"2021-11-14T23:23:14.576430+03:00","diagnostic":{"severity":"error","summary":"Missing required argument","detail":"The argument \"name\" is required, but no definition was found.","range":{"filename":"main.tf.json","start":{"line":24,"column":7,"byte":568},"end":{"line":24,"column":8,"byte":569}},"snippet":{"context":"resource.azurerm_resource_group.example","code":"      }","start_line":24,"highlight_start_offset":6,"highlight_end_offset":7,"values":[]}},"type":"diagnostic"}`)
+	errorBoom = errors.New("boom")
+)
+
+func TestIsApplyFailed(t *testing.T) {
+	var nilApplyErr *applyFailed
+	type args struct {
+		err error
+	}
+	tests := map[string]struct {
+		args args
+		want bool
+	}{
+		"NilError": {
+			args: args{},
+			want: false,
+		},
+		"NilApplyError": {
+			args: args{
+				err: nilApplyErr,
+			},
+			want: true,
+		},
+		"NonApplyError": {
+			args: args{
+				err: errorBoom,
+			},
+			want: false,
+		},
+		"ApplyErrorNoLog": {
+			args: args{
+				err: WrapApplyFailed(errorBoom, nil),
+			},
+			want: true,
+		},
+		"ApplyErrorWithLog": {
+			args: args{
+				err: WrapApplyFailed(errorBoom, errorLog),
+			},
+			want: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := IsApplyFailed(tt.args.err); got != tt.want {
+				t.Errorf("IsApplyFailed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDestroyFailed(t *testing.T) {
+	var nilDestroyErr *destroyFailed
+	type args struct {
+		err error
+	}
+	tests := map[string]struct {
+		args args
+		want bool
+	}{
+		"NilError": {
+			args: args{},
+			want: false,
+		},
+		"NilDestroyError": {
+			args: args{
+				err: nilDestroyErr,
+			},
+			want: true,
+		},
+		"NonDestroyError": {
+			args: args{
+				err: errorBoom,
+			},
+			want: false,
+		},
+		"DestroyErrorNoLog": {
+			args: args{
+				err: WrapDestroyFailed(errorBoom, nil),
+			},
+			want: true,
+		},
+		"DestroyErrorWithLog": {
+			args: args{
+				err: WrapDestroyFailed(errorBoom, errorLog),
+			},
+			want: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := IsDestroyFailed(tt.args.err); got != tt.want {
+				t.Errorf("IsDestroyFailed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapApplyFailed(t *testing.T) {
+	type args struct {
+		cause error
+		logs  []byte
+	}
+	tests := map[string]struct {
+		args           args
+		wantErrMessage string
+	}{
+		"NilCause": {
+			args: args{},
+		},
+		"ApplyError": {
+			args: args{
+				cause: errorBoom,
+				logs:  errorLog,
+			},
+			wantErrMessage: "apply failed: Missing required argument: The argument \"location\" is required, but no definition was found.\nMissing required argument: The argument \"name\" is required, but no definition was found.",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := WrapApplyFailed(tt.args.cause, tt.args.logs)
+			got := ""
+			if err != nil {
+				got = err.Error()
+			}
+			if diff := cmp.Diff(tt.wantErrMessage, got); diff != "" {
+				t.Errorf("\nWrapApplyFailed(...): -want message, +got message:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWrapDestroyFailed(t *testing.T) {
+	type args struct {
+		cause error
+		logs  []byte
+	}
+	tests := map[string]struct {
+		args           args
+		wantErrMessage string
+	}{
+		"NilCause": {
+			args: args{},
+		},
+		"DestroyError": {
+			args: args{
+				cause: errorBoom,
+				logs:  errorLog,
+			},
+			wantErrMessage: "destroy failed: Missing required argument: The argument \"location\" is required, but no definition was found.\nMissing required argument: The argument \"name\" is required, but no definition was found.",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := WrapDestroyFailed(tt.args.cause, tt.args.logs)
+			got := ""
+			if err != nil {
+				got = err.Error()
+			}
+			if diff := cmp.Diff(tt.wantErrMessage, got); diff != "" {
+				t.Errorf("\nWrapApplyFailed(...): -want message, +got message:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWrapTFError(t *testing.T) {
+	type args struct {
+		cause error
+		logs  []byte
+	}
+	tests := map[string]struct {
+		args           args
+		wantErrMessage string
+	}{
+		"NilCause": {
+			args: args{},
+		},
+		"ApplyError": {
+			args: args{
+				cause: errorBoom,
+				logs:  errorLog,
+			},
+			wantErrMessage: "test operation: Missing required argument: The argument \"location\" is required, but no definition was found.\nMissing required argument: The argument \"name\" is required, but no definition was found.",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := WrapTFError("test operation", tt.args.cause, tt.args.logs)
+			got := ""
+			if err != nil {
+				got = err.Error()
+			}
+			if diff := cmp.Diff(tt.wantErrMessage, got); diff != "" {
+				t.Errorf("\nWrapApplyFailed(...): -want message, +got message:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/terraform/workspace.go
+++ b/pkg/terraform/workspace.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/pkg/errors"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
 	"github.com/crossplane-contrib/terrajet/pkg/resource/json"
 	tferrors "github.com/crossplane-contrib/terrajet/pkg/terraform/errors"
@@ -88,16 +89,12 @@ func (w *Workspace) ApplyAsync(callback CallbackFn) error {
 		out, err := cmd.CombinedOutput()
 		w.LastOperation.MarkEnd()
 		w.logger.Debug("apply async ended", "out", string(out))
+		err = tferrors.WrapApplyFailed(err, out)
 		defer func() {
 			if cErr := callback(err, ctx); cErr != nil {
 				w.logger.Info("callback failed", "error", cErr.Error())
 			}
 		}()
-		if err != nil {
-			// Only the last line contains the error.
-			l := strings.Split(string(out), "\n")
-			err = tferrors.NewApplyFailed(errors.Wrap(err, l[len(l)-2]).Error())
-		}
 	}()
 	return nil
 }
@@ -117,7 +114,7 @@ func (w *Workspace) Apply(ctx context.Context) (ApplyResult, error) {
 	out, err := cmd.CombinedOutput()
 	w.logger.Debug("apply ended", "out", string(out))
 	if err != nil {
-		return ApplyResult{}, errors.Wrapf(err, "cannot apply: %s", string(out))
+		return ApplyResult{}, tferrors.WrapApplyFailed(err, out)
 	}
 	raw, err := os.ReadFile(filepath.Join(w.dir, "terraform.tfstate"))
 	if err != nil {
@@ -153,16 +150,12 @@ func (w *Workspace) DestroyAsync(callback CallbackFn) error {
 		out, err := cmd.CombinedOutput()
 		w.LastOperation.MarkEnd()
 		w.logger.Debug("destroy async ended", "out", string(out))
+		err = tferrors.WrapDestroyFailed(err, out)
 		defer func() {
 			if cErr := callback(err, ctx); cErr != nil {
 				w.logger.Info("callback failed", "error", cErr.Error())
 			}
 		}()
-		if err != nil {
-			// Only the last line contains the error.
-			l := strings.Split(string(out), "\n")
-			err = tferrors.NewDestroyFailed(l[len(l)-2])
-		}
 	}()
 	return nil
 }
@@ -176,7 +169,7 @@ func (w *Workspace) Destroy(ctx context.Context) error {
 	w.configureCmd(cmd)
 	out, err := cmd.CombinedOutput()
 	w.logger.Debug("destroy ended", "out", string(out))
-	return errors.Wrapf(err, "cannot destroy: %s", string(out))
+	return tferrors.WrapDestroyFailed(err, out)
 }
 
 // RefreshResult contains information about the current state of the resource.
@@ -204,7 +197,7 @@ func (w *Workspace) Refresh(ctx context.Context) (RefreshResult, error) {
 	out, err := cmd.CombinedOutput()
 	w.logger.Debug("refresh ended", "out", string(out))
 	if err != nil {
-		return RefreshResult{}, errors.Wrapf(err, "cannot refresh: %s", string(out))
+		return RefreshResult{}, tferrors.WrapTFError("cannot refresh", err, out)
 	}
 	raw, err := os.ReadFile(filepath.Join(w.dir, "terraform.tfstate"))
 	if err != nil {
@@ -238,7 +231,7 @@ func (w *Workspace) Plan(ctx context.Context) (PlanResult, error) {
 	out, err := cmd.CombinedOutput()
 	w.logger.Debug("plan ended", "out", string(out))
 	if err != nil {
-		return PlanResult{}, errors.Wrapf(err, "cannot plan: %s", string(out))
+		return PlanResult{}, tferrors.WrapTFError("cannot plan", err, out)
 	}
 	line := ""
 	for _, l := range strings.Split(string(out), "\n") {


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #44

This PR proposes changes that parse the actual error messages from respective JSON-formatted Terraform CLI logs in case the Terraform CLI pipeline fails.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
On top of https://github.com/crossplane-contrib/provider-tf-azure/pull/83, an errored condition without these changes results in:
```
status:
  atProvider: {}
  conditions:
  - lastTransitionTime: "2021-11-15T14:05:25Z"
    reason: Creating
    status: "False"
    type: Ready
  - lastTransitionTime: "2021-11-15T14:05:25Z"
    message: |-
      create failed: cannot apply: cannot apply: {"@level":"info","@message":"Terraform 1.0.3","@module":"terraform.ui","@timestamp":"2021-11-15T17:05:05.983000+03:00","terraform":"1.0.3","type":"version","ui":"0.1.0"}
      {"@level":"info","@message":"azurerm_resource_group.example-alper-2: Plan to create","@module":"terraform.ui","@timestamp":"2021-11-15T17:05:15.213746+03:00","change":{"resource":{"addr":"azurerm_resource_group.example-alper-2","module":"","resource":"azurerm_resource_group.example-alper-2","implied_provider":"azurerm","resource_type":"azurerm_resource_group","resource_name":"example-alper-2","resource_key":null},"action":"create"},"type":"planned_change"}
      {"@level":"info","@message":"Plan: 1 to add, 0 to change, 0 to destroy.","@module":"terraform.ui","@timestamp":"2021-11-15T17:05:15.213823+03:00","changes":{"add":1,"change":0,"remove":0,"operation":"plan"},"type":"change_summary"}
      {"@level":"info","@message":"azurerm_resource_group.example-alper-2: Creating...","@module":"terraform.ui","@timestamp":"2021-11-15T17:05:24.376958+03:00","hook":{"resource":{"addr":"azurerm_resource_group.example-alper-2","module":"","resource":"azurerm_resource_group.example-alper-2","implied_provider":"azurerm","resource_type":"azurerm_resource_group","resource_name":"example-alper-2","resource_key":null},"action":"create"},"type":"apply_start"}
      {"@level":"info","@message":"azurerm_resource_group.example-alper-2: Creation errored after 1s","@module":"terraform.ui","@timestamp":"2021-11-15T17:05:24.985199+03:00","hook":{"resource":{"addr":"azurerm_resource_group.example-alper-2","module":"","resource":"azurerm_resource_group.example-alper-2","implied_provider":"azurerm","resource_type":"azurerm_resource_group","resource_name":"example-alper-2","resource_key":null},"action":"create","elapsed_seconds":1},"type":"apply_errored"}
      {"@level":"error","@message":"Error: A resource with the ID \"/subscriptions/.../resourceGroups/example-resourcegroup-alper\" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for \"azurerm_resource_group\" for more information.","@module":"terraform.ui","@timestamp":"2021-11-15T17:05:25.033488+03:00","diagnostic":{"severity":"error","summary":"A resource with the ID \"/subscriptions/.../resourceGroups/example-resourcegroup-alper\" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for \"azurerm_resource_group\" for more information.","detail":"","address":"azurerm_resource_group.example-alper-2","range":{"filename":"main.tf.json","start":{"line":1,"column":228,"byte":227},"end":{"line":1,"column":229,"byte":228}},"snippet":{"context":"resource.azurerm_resource_group.example-alper-2.tags","code":"{\"provider\":{\"azurerm\":{\"features\":{}}},\"resource\":{\"azurerm_resource_group\":{\"example-alper-2\":{\"lifecycle\":{\"prevent_destroy\":true},\"location\":\"East US\",\"name\":\"example-resourcegroup-alper\",\"tags\":{\"provisioner\":\"crossplane\"}}}},\"terraform\":{\"required_providers\":{\"azurerm\":{\"source\":\"hashicorp/azurerm\",\"version\":\"2.78.0\"}}}}","start_line":1,"highlight_start_offset":227,"highlight_end_offset":228,"values":[]}},"type":"diagnostic"}
      : exit status 1
    reason: ReconcileError
    status: "False"
    type: Synced
```

With the proposed changes:
```
status:
  atProvider: {}
  conditions:
  - lastTransitionTime: "2021-11-15T14:05:25Z"
    reason: Creating
    status: "False"
    type: Ready
  - lastTransitionTime: "2021-11-15T14:22:13Z"
    message: 'create failed: cannot apply: apply failed: A resource with the ID "/subscriptions/.../resourceGroups/example-resourcegroup-alper"
      already exists - to be managed via Terraform this resource needs to be imported
      into the State. Please see the resource documentation for "azurerm_resource_group"
      for more information.: '
    reason: ReconcileError
    status: "False"
    type: Synced
```

[contribution process]: https://git.io/fj2m9
