### PR TITLE
Rename Group to ShortGroup and allow empty short group

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -83,9 +83,9 @@ func DefaultResource(name string, terraformSchema *schema.Resource) *Resource {
 		Name:              name,
 		TerraformResource: terraformSchema,
 
-		ShortGroupName: group,
-		Kind:           kind,
-		Version:        "v1alpha1",
+		ShortGroup: group,
+		Kind:       kind,
+		Version:    "v1alpha1",
 
 		IDFieldName:  "id",
 		ExternalName: NameAsIdentifier,

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -83,9 +83,9 @@ func DefaultResource(name string, terraformSchema *schema.Resource) *Resource {
 		Name:              name,
 		TerraformResource: terraformSchema,
 
-		Group:   group,
-		Kind:    kind,
-		Version: "v1alpha1",
+		ShortGroupName: group,
+		Kind:           kind,
+		Version:        "v1alpha1",
 
 		IDFieldName:  "id",
 		ExternalName: NameAsIdentifier,

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -52,13 +52,17 @@ type Provider struct {
 	// for "aws_rds_cluster", we drop "aws_" prefix and its group ("rds") to set
 	// Kind of the resource as "Cluster".
 	TerraformResourcePrefix string
-	// GroupSuffix is the suffix to append to resource groups, e.g.
-	// ".aws.tf.crossplane.io". Defaults to ".<prefix>.tf.crossplane.io".
-	GroupSuffix string
+
+	// RootGroup is the root group that all CRDs groups in the provider are based
+	// on, e.g. "aws.tf.crossplane.io".
+	// Defaults to "<TerraformResourcePrefix>.tf.crossplane.io".
+	RootGroup string
+
 	// ShortName is the short name of the provider. Typically, added as a CRD
 	// category, e.g. "tfaws". Default to "tf<prefix>". For more details on CRD
 	// categories, see: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#categories
 	ShortName string
+
 	// ModulePath is the go module path for the tf based provider repo, e.g.
 	// "github.com/crossplane-contrib/provider-tf-aws"
 	ModulePath string
@@ -77,6 +81,7 @@ type Provider struct {
 	// can add "aws_shield_protection_group$". To skip whole aws waf group, one
 	// can add "aws_waf.*" to the list.
 	SkipList []string
+
 	// IncludeList is a list of regex for the Terraform resources to be
 	// skipped. For example, to include "aws_shield_protection_group" into
 	// the generated resources, one can add "aws_shield_protection_group$".
@@ -96,10 +101,10 @@ type Provider struct {
 // A ProviderOption configures a Provider.
 type ProviderOption func(*Provider)
 
-// WithGroupSuffix configures GroupSuffix for resources of this Provider.
+// WithGroupSuffix configures RootGroup for resources of this Provider.
 func WithGroupSuffix(s string) ProviderOption {
 	return func(p *Provider) {
-		p.GroupSuffix = s
+		p.RootGroup = s
 	}
 }
 
@@ -143,7 +148,7 @@ func NewProvider(resourceMap map[string]*schema.Resource, prefix string, moduleP
 	p := &Provider{
 		ModulePath:              modulePath,
 		TerraformResourcePrefix: fmt.Sprintf("%s_", prefix),
-		GroupSuffix:             fmt.Sprintf(".%s.tf.crossplane.io", prefix),
+		RootGroup:               fmt.Sprintf("%s.tf.crossplane.io", prefix),
 		ShortName:               fmt.Sprintf("tf%s", prefix),
 		BasePackages:            DefaultBasePackages,
 		DefaultResourceFn:       DefaultResource,

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -160,12 +160,12 @@ type Resource struct {
 	// to overwrite it.
 	IDFieldName string
 
-	// ShortGroupName is the short name of the API group of this CRD. The full
+	// ShortGroup is the short name of the API group of this CRD. The full
 	// CRD API group is calculated by adding the group suffix of the provider.
-	// For example, ShortGroupName could be `ec2` where group suffix of the
+	// For example, ShortGroup could be `ec2` where group suffix of the
 	// provider is `aws.crossplane.io` and in that case, the full group would
 	// be `ec2.aws.crossplane.io`
-	ShortGroupName string
+	ShortGroup string
 
 	// Version is the version CRD will have.
 	Version string

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -160,8 +160,12 @@ type Resource struct {
 	// to overwrite it.
 	IDFieldName string
 
-	// Group is the group of CRD.
-	Group string
+	// ShortGroupName is the short name of the API group of this CRD. The full
+	// CRD API group is calculated by adding the group suffix of the provider.
+	// For example, ShortGroupName could be `ec2` where group suffix of the
+	// provider is `aws.crossplane.io` and in that case, the full group would
+	// be `ec2.aws.crossplane.io`
+	ShortGroupName string
 
 	// Version is the version CRD will have.
 	Version string

--- a/pkg/pipeline/run.go
+++ b/pkg/pipeline/run.go
@@ -37,13 +37,13 @@ func Run(pc *config.Provider, rootDir string) { // nolint:gocyclo
 	// Group resources based on their Group and API Versions.
 	resourcesGroups := map[string]map[string]map[string]*config.Resource{}
 	for name, resource := range pc.Resources {
-		if len(resourcesGroups[resource.Group]) == 0 {
-			resourcesGroups[resource.Group] = map[string]map[string]*config.Resource{}
+		if len(resourcesGroups[resource.ShortGroupName]) == 0 {
+			resourcesGroups[resource.ShortGroupName] = map[string]map[string]*config.Resource{}
 		}
-		if len(resourcesGroups[resource.Group][resource.Version]) == 0 {
-			resourcesGroups[resource.Group][resource.Version] = map[string]*config.Resource{}
+		if len(resourcesGroups[resource.ShortGroupName][resource.Version]) == 0 {
+			resourcesGroups[resource.ShortGroupName][resource.Version] = map[string]*config.Resource{}
 		}
-		resourcesGroups[resource.Group][resource.Version][name] = resource
+		resourcesGroups[resource.ShortGroupName][resource.Version][name] = resource
 	}
 
 	// Add ProviderConfig API package to the list of API version packages.


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

`Group` is actually the full API group like `ec2.aws.crossplane.io` but it seems like the content we're expecting there is not of that form, so I changed its name. Also, I added a logic to allow `""` short group so that some resources can be in provider level group, like `ResourceGroup` in Azure where it should be in `tfazure.crossplane.io`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N/A
