### PR TITLE
pipeline: prepend group and version with CRD so that CRDs whose name is Group can be generated

### DIFF
--- a/pkg/pipeline/templates/crd_types.go.tmpl
+++ b/pkg/pipeline/templates/crd_types.go.tmpl
@@ -53,9 +53,9 @@ type {{ .CRD.Kind }}List struct {
 // Repository type metadata.
 var (
 	{{ .CRD.Kind }}_Kind             = "{{ .CRD.Kind }}"
-	{{ .CRD.Kind }}_GroupKind        = schema.GroupKind{Group: Group, Kind: {{ .CRD.Kind }}_Kind}.String()
-	{{ .CRD.Kind }}_KindAPIVersion   = {{ .CRD.Kind }}_Kind + "." + GroupVersion.String()
-	{{ .CRD.Kind }}_GroupVersionKind = GroupVersion.WithKind({{ .CRD.Kind }}_Kind)
+	{{ .CRD.Kind }}_GroupKind        = schema.GroupKind{Group: CRDGroup, Kind: {{ .CRD.Kind }}_Kind}.String()
+	{{ .CRD.Kind }}_KindAPIVersion   = {{ .CRD.Kind }}_Kind + "." + CRDGroupVersion.String()
+	{{ .CRD.Kind }}_GroupVersionKind = CRDGroupVersion.WithKind({{ .CRD.Kind }}_Kind)
 )
 
 func init() {

--- a/pkg/pipeline/templates/groupversion_info.go.tmpl
+++ b/pkg/pipeline/templates/groupversion_info.go.tmpl
@@ -4,8 +4,8 @@
 
 // +kubebuilder:object:generate=true
 // +groupName={{ .CRD.Group }}
-// +versionName={{ .CRD.APIVersion }}
-package {{ .CRD.APIVersion }}
+// +versionName={{ .CRD.Version }}
+package {{ .CRD.Version }}
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -14,16 +14,16 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "{{ .CRD.Group }}"
-	Version = "{{ .CRD.APIVersion }}"
+	CRDGroup   = "{{ .CRD.Group }}"
+	CRDVersion = "{{ .CRD.Version }}"
 )
 
 var (
-	// GroupVersion is the API Group Version used to register the objects
-	GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
+	// CRDGroupVersion is the API Group Version used to register the objects
+	CRDGroupVersion = schema.GroupVersion{Group: CRDGroup, Version: CRDVersion}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = &scheme.Builder{GroupVersion: CRDGroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/pipeline/version.go
+++ b/pkg/pipeline/version.go
@@ -54,8 +54,8 @@ type VersionGenerator struct {
 func (vg *VersionGenerator) Generate() error {
 	vars := map[string]interface{}{
 		"CRD": map[string]string{
-			"APIVersion": vg.Version,
-			"Group":      vg.Group,
+			"Version": vg.Version,
+			"Group":   vg.Group,
 		},
 	}
 	gviFile := wrapper.NewFile(vg.pkg.Path(), vg.Version, templates.GroupVersionInfoTemplate,


### PR DESCRIPTION
### Description of your changes

Otherwise `Group` conflicts with `Group` in `iam`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually with proivder-tf-aws.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
