### PR TITLE
pipeline: sort import order

### DIFF
--- a/pkg/pipeline/register.go
+++ b/pkg/pipeline/register.go
@@ -50,11 +50,11 @@ func (rg *RegisterGenerator) Generate(versionPkgList []string) error {
 		wrapper.WithGenStatement(GenStatement),
 		wrapper.WithHeaderPath(rg.LicenseHeaderPath),
 	)
+	sort.Strings(versionPkgList)
 	aliases := make([]string, len(versionPkgList))
 	for i, pkgPath := range versionPkgList {
 		aliases[i] = registerFile.Imports.UsePackage(pkgPath)
 	}
-	sort.Strings(aliases)
 	vars := map[string]interface{}{
 		"Aliases": aliases,
 	}

--- a/pkg/pipeline/run.go
+++ b/pkg/pipeline/run.go
@@ -63,10 +63,8 @@ func Run(pc *config.Provider, rootDir string) { // nolint:gocyclo
 		controllerPkgList = append(controllerPkgList, filepath.Join(pc.ModulePath, p))
 	}
 	count := 0
-	for _, group := range sortedGroups(resourcesGroups) {
-		versions := resourcesGroups[group]
-		for _, version := range sortedVersions(versions) {
-			resources := versions[version]
+	for group, versions := range resourcesGroups {
+		for version, resources := range versions {
 			versionGen := NewVersionGenerator(rootDir, pc.ModulePath, group, version)
 			crdGen := NewCRDGenerator(versionGen.Package(), rootDir, pc.ShortName, group, version)
 			tfGen := NewTerraformedGenerator(versionGen.Package(), rootDir, group, version)
@@ -117,30 +115,6 @@ func Run(pc *config.Provider, rootDir string) { // nolint:gocyclo
 	}
 
 	fmt.Printf("\nGenerated %d resources!\n", count)
-}
-
-// We will have generics one day. But until then..
-
-func sortedGroups(m map[string]map[string]map[string]*config.Resource) []string {
-	result := make([]string, len(m))
-	i := 0
-	for g := range m {
-		result[i] = g
-		i++
-	}
-	sort.Strings(result)
-	return result
-}
-
-func sortedVersions(m map[string]map[string]*config.Resource) []string {
-	result := make([]string, len(m))
-	i := 0
-	for g := range m {
-		result[i] = g
-		i++
-	}
-	sort.Strings(result)
-	return result
 }
 
 func sortedResources(m map[string]*config.Resource) []string {

--- a/pkg/pipeline/setup.go
+++ b/pkg/pipeline/setup.go
@@ -50,11 +50,11 @@ func (sg *SetupGenerator) Generate(versionPkgList []string) error {
 		wrapper.WithGenStatement(GenStatement),
 		wrapper.WithHeaderPath(sg.LicenseHeaderPath),
 	)
+	sort.Strings(versionPkgList)
 	aliases := make([]string, len(versionPkgList))
 	for i, pkgPath := range versionPkgList {
 		aliases[i] = setupFile.Imports.UsePackage(pkgPath)
 	}
-	sort.Strings(aliases)
 	vars := map[string]interface{}{
 		"Aliases": aliases,
 	}


### PR DESCRIPTION
### Description of your changes

Follow-up for https://github.com/crossplane-contrib/terrajet/pull/148 . It seems like this was the real issue because `UsePackage` command returns string that depends on the existing keys in the import map, so only that ordering matters. I reverted group and version sorting since I couldn't think of a case that it might be necessary.

Fixes https://github.com/crossplane-contrib/terrajet/issues/139

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Ran `make generate` a few times with https://github.com/crossplane-contrib/provider-tf-aws/pull/128 and saw no changes.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
