### PR TITLE
pipeline: use generated parameters name instead of hard-coded

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ See [design document][design-doc] for more details.
 
 Feel free to test the following Crossplane providers built using Terrajet:
 
-* [Provider TF AWS](https://github.com/crossplane-contrib/provider-jet-aws/releases)
-* [Provider TF Azure](https://github.com/crossplane-contrib/provider-jet-azure/releases)
-* [Provider TF GCP](https://github.com/crossplane-contrib/provider-jet-gcp/releases)
+* [Provider Jet AWS](https://github.com/crossplane-contrib/provider-jet-aws/releases)
+* [Provider Jet Azure](https://github.com/crossplane-contrib/provider-jet-azure/releases)
+* [Provider Jet GCP](https://github.com/crossplane-contrib/provider-jet-gcp/releases)
 
-**NOTE**: Terrajet is in its very early stages. We expect many breaking changes
-in the coming weeks. Relying on it for production usage is not recommended yet.
+**NOTE**: Terrajet is in its very early stages and we're making many changes that
+can affect the output and the runtime. Please check the generated code before
+running in production.
 
 ## Report a Bug
 

--- a/pkg/pipeline/run.go
+++ b/pkg/pipeline/run.go
@@ -71,10 +71,11 @@ func Run(pc *config.Provider, rootDir string) { // nolint:gocyclo
 			ctrlGen := NewControllerGenerator(rootDir, pc.ModulePath, group)
 
 			for _, name := range sortedResources(resources) {
-				if err := crdGen.Generate(resources[name]); err != nil {
+				paramTypeName, err := crdGen.Generate(resources[name])
+				if err != nil {
 					panic(errors.Wrapf(err, "cannot generate crd for resource %s", name))
 				}
-				if err := tfGen.Generate(resources[name]); err != nil {
+				if err := tfGen.Generate(resources[name], paramTypeName); err != nil {
 					panic(errors.Wrapf(err, "cannot generate terraformed for resource %s", name))
 				}
 				ctrlPkgPath, err := ctrlGen.Generate(resources[name], versionGen.Package().Path())

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -67,7 +67,7 @@ func (tr *{{ .CRD.Kind }}) SetParameters(params map[string]interface{}) error {
 // LateInitialize this {{ .CRD.Kind }} using its observed tfState.
 // returns True if there are any spec changes for the resource.
 func (tr *{{ .CRD.Kind }}) LateInitialize(attrs []byte) (bool, error) {
-	params := &{{ .CRD.Kind }}Parameters{}
+	params := &{{ .CRD.ParametersTypeName }}{}
 	if err := json.TFParser.Unmarshal(attrs, params); err != nil {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}

--- a/pkg/pipeline/terraformed.go
+++ b/pkg/pipeline/terraformed.go
@@ -49,15 +49,16 @@ type TerraformedGenerator struct {
 }
 
 // Generate writes generated Terraformed interface functions
-func (tg *TerraformedGenerator) Generate(cfg *config.Resource) error {
+func (tg *TerraformedGenerator) Generate(cfg *config.Resource, parametersTypeName string) error {
 	trFile := wrapper.NewFile(tg.pkg.Path(), tg.pkg.Name(), templates.TerraformedTemplate,
 		wrapper.WithGenStatement(GenStatement),
 		wrapper.WithHeaderPath(tg.LicenseHeaderPath),
 	)
 	vars := map[string]interface{}{
 		"CRD": map[string]string{
-			"APIVersion": cfg.Version,
-			"Kind":       cfg.Kind,
+			"APIVersion":         cfg.Version,
+			"Kind":               cfg.Kind,
+			"ParametersTypeName": parametersTypeName,
 		},
 		"Terraform": map[string]interface{}{
 			"ResourceType":  cfg.Name,


### PR DESCRIPTION
### Description of your changes

I got `NetworkInterfaceParameters_2` for `NetworkInterface` due to duplicate with `NetworkInterfaceParameters` struct of `Instance` and late-init rightfully returned error saying that the types should match. This PR makes sure we create an instance of parameters type we generated for that CRD.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

With Jet AWS provider.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
