### PR TITLE
Make Terraform resource ID available in status.atProvider

### DIFF
--- a/pkg/pipeline/crd.go
+++ b/pkg/pipeline/crd.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	twtypes "github.com/muvaf/typewriter/pkg/types"
 	"github.com/muvaf/typewriter/pkg/wrapper"
 	"github.com/pkg/errors"
@@ -66,6 +67,12 @@ func (cg *CRDGenerator) Generate(cfg *config.Resource) (string, error) {
 	for _, omit := range cfg.ExternalName.OmittedFields {
 		delete(cfg.TerraformResource.Schema, omit)
 	}
+
+	cfg.TerraformResource.Schema["id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+
 	gen, err := tjtypes.NewBuilder(cg.pkg).Build(cfg)
 	if err != nil {
 		return "", errors.Wrapf(err, "cannot build types for %s", cfg.Kind)

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -55,6 +55,11 @@ func (tr *{{ .CRD.Kind }}) SetObservation(obs map[string]interface{}) error {
 	return json.TFParser.Unmarshal(p, &tr.Status.AtProvider)
 }
 
+// GetObservation of this {{ .CRD.Kind }}
+func (tr *{{ .CRD.Kind }}) GetID() string {
+    return tr.Status.AtProvider.ID
+}
+
 // GetParameters of this {{ .CRD.Kind }}
 func (tr *{{ .CRD.Kind }}) GetParameters() (map[string]interface{}, error) {
 	p, err := json.TFParser.Marshal(tr.Spec.ForProvider)

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -38,6 +38,16 @@ func (tr *{{ .CRD.Kind }}) GetObservation() (map[string]interface{}, error) {
 
 // SetObservation for this {{ .CRD.Kind }}
 func (tr *{{ .CRD.Kind }}) SetObservation(obs map[string]interface{}) error {
+    id, ok := obs["id"]
+    if !ok {
+        return errors.New("attribute id not found in observed state")
+    }
+    idStr, ok := id.(string)
+    if !ok {
+        return errors.New("attribute id in observed state is not of type string")
+    }
+    tr.Status.AtProvider.ID = idStr
+
 	p, err := json.TFParser.Marshal(obs)
 	if err != nil {
 		return err

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -38,16 +38,6 @@ func (tr *{{ .CRD.Kind }}) GetObservation() (map[string]interface{}, error) {
 
 // SetObservation for this {{ .CRD.Kind }}
 func (tr *{{ .CRD.Kind }}) SetObservation(obs map[string]interface{}) error {
-    id, ok := obs["id"]
-    if !ok {
-        return errors.New("attribute id not found in observed state")
-    }
-    idStr, ok := id.(string)
-    if !ok {
-        return errors.New("attribute id in observed state is not of type string")
-    }
-    tr.Status.AtProvider.ID = idStr
-
 	p, err := json.TFParser.Marshal(obs)
 	if err != nil {
 		return err
@@ -57,7 +47,10 @@ func (tr *{{ .CRD.Kind }}) SetObservation(obs map[string]interface{}) error {
 
 // GetObservation of this {{ .CRD.Kind }}
 func (tr *{{ .CRD.Kind }}) GetID() string {
-    return tr.Status.AtProvider.ID
+    if tr.Status.AtProvider.ID == nil {
+        return ""
+    }
+    return *tr.Status.AtProvider.ID
 }
 
 // GetParameters of this {{ .CRD.Kind }}

--- a/pkg/resource/fake/terraformed.go
+++ b/pkg/resource/fake/terraformed.go
@@ -28,6 +28,7 @@ import (
 type Observable struct {
 	Observation                 map[string]interface{}
 	AdditionalConnectionDetails map[string][]byte
+	ID                          string
 }
 
 // GetObservation is a mock.
@@ -39,6 +40,11 @@ func (o *Observable) GetObservation() (map[string]interface{}, error) {
 func (o *Observable) SetObservation(data map[string]interface{}) error {
 	o.Observation = data
 	return nil
+}
+
+// GetID is a mock.
+func (o *Observable) GetID() string {
+	return o.ID
 }
 
 // GetAdditionalConnectionDetails is a mock

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -24,6 +24,7 @@ import (
 type Observable interface {
 	GetObservation() (map[string]interface{}, error)
 	SetObservation(map[string]interface{}) error
+	GetID() string
 }
 
 // Parameterizable structs can get and set parameters of the managed resource

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -100,7 +100,6 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 	var paramTags []string       //nolint:prealloc
 	var obsFields []*types.Var   //nolint:prealloc
 	var obsTags []string         //nolint:prealloc
-	rootLevelObject, idObservationAdded := len(names) == 1, false
 	for _, snakeFieldName := range keys {
 		sch := res.Schema[snakeFieldName]
 		fieldName := NewNameFromSnake(snakeFieldName)
@@ -142,9 +141,6 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 		fieldNameCamel := fieldName.Camel
 		if sch.Sensitive {
 			if isObservation(sch) {
-				if rootLevelObject && fieldName.Snake == "id" {
-					return nil, nil, errors.New(`unexpected sensitive field "id"`)
-				}
 				cfg.Sensitive.AddFieldPath(fieldPathWithWildcard(tfPaths), "status.atProvider."+fieldPathWithWildcard(xpPaths))
 				// Drop an observation field from schema if it is sensitive.
 				// Data will be stored in connection details secret
@@ -185,12 +181,6 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 		case isObservation(sch):
 			obsFields = append(obsFields, field)
 			obsTags = append(obsTags, fmt.Sprintf(`json:"%s" tf:"%s"`, jsonTag, tfTag))
-			if rootLevelObject && fieldName.Snake == "id" {
-				if fieldType.String() != "string" {
-					return nil, nil, errors.Errorf("expecting id attribute of type string but got %q", fieldType.String())
-				}
-				idObservationAdded = true
-			}
 		default:
 			if sch.Optional {
 				paramTags = append(paramTags, fmt.Sprintf(`json:"%s" tf:"%s"`, jsonTag, tfTag))
@@ -211,12 +201,6 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 		}
 
 		g.comments.AddFieldComment(paramName, fieldNameCamel, comment.Build())
-	}
-
-	if rootLevelObject && !idObservationAdded {
-		// add "id" field of type string to hold the resource's observed persistent ID
-		obsFields = append(obsFields, types.NewField(token.NoPos, g.Package, "ID", types.Universe.Lookup("string").Type(), false))
-		obsTags = append(obsTags, fmt.Sprintf(`json:"%s" tf:"%s"`, "id,omitempty", "-"))
 	}
 
 	// NOTE(muvaf): Not every struct has both computed and configurable fields,


### PR DESCRIPTION
Signed-off-by: Alper Rifat Ulucinar <ulucinar@users.noreply.github.com>

<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #154 

This PR proposes a change to make the persistent ID available in the Terraform state part of `status.atProvider` of the generated managed resource.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
