### PR TITLE
Directions for calling ./hack/prepare.sh in the provider guide

### DIFF
--- a/docs/generating-a-provider.md
+++ b/docs/generating-a-provider.md
@@ -20,17 +20,11 @@ be quite similar for any other Terraform provider.
         export ProviderNameUpper=GitHub
         ```
 
-    2. Replace all occurrences of `template` with your provider name:
+    2. Run the `./hack/prepare.sh` script from repo root to prepare the repo, e.g., to 
+       replace all occurrences of `template` with your provider name:
 
         ```bash
-        git grep -l 'template' -- './*' ':!build/**' ':!go.sum' | xargs sed -i.bak "s/template/${ProviderNameLower}/g"
-        git grep -l 'Template' -- './*' ':!build/**' ':!go.sum' | xargs sed -i.bak "s/Template/${ProviderNameUpper}/g"
-        # Clean up the .bak files created by sed
-        git clean -fd
-   
-        git mv "internal/clients/template.go" "internal/clients/${ProviderNameLower}.go"
-        git mv "cluster/images/provider-jet-template" "cluster/images/provider-jet-${ProviderNameLower}"
-        git mv "cluster/images/provider-jet-template-controller" "cluster/images/provider-jet-${ProviderNameLower}-controller"
+       ./hack/prepare.sh
         ```
 
 4. Configure your repo for the Terraform provider binary and schema:


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
In the context of https://github.com/crossplane-contrib/provider-jet-template/issues/3, this change proposes to move repo preparation shell commands into the script `hack/prepare.sh` of `crossplane-contrib/provider-jet-template`. This has some advantages like:
- Simplifying the provider guide a bit
- Decoupling the two repos a bit: For instance, as we might further evolve the `hack/prepare.sh` script in `crossplane-contrib/provider-jet-template`, the guide just instructs the user to call it.

Depends on https://github.com/crossplane-contrib/provider-jet-template/pull/9

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Not a full test of the guide, however, tested by running `hack/prepare.sh` in https://github.com/crossplane-contrib/provider-jet-template/pull/9.

[contribution process]: https://git.io/fj2m9
