### PR TITLE
Handle sensitive optionals coming as null

### DIFF
--- a/pkg/resource/sensitive_test.go
+++ b/pkg/resource/sensitive_test.go
@@ -426,13 +426,6 @@ func TestGetSensitiveParameters(t *testing.T) {
 						},
 						Key: "pass",
 					})).Return([]byte("foo"), nil)
-					/*					client.EXPECT().GetSecretValue(gomock.Any(), gomock.Eq(xpv1.SecretKeySelector{
-										SecretReference: xpv1.SecretReference{
-											Name:      "admin-key",
-											Namespace: "crossplane-system",
-										},
-										Key: "key",
-									})).Return([]byte("bar"), nil)*/
 				},
 				from: &unstructured.Unstructured{
 					Object: map[string]interface{}{
@@ -443,11 +436,6 @@ func TestGetSensitiveParameters(t *testing.T) {
 									"namespace": "crossplane-system",
 									"key":       "pass",
 								},
-								/*"adminKeySecretRef": map[string]interface{}{
-									"name":      "admin-key",
-									"namespace": "crossplane-system",
-									"key":       "key",
-								},*/
 							},
 						},
 					},


### PR DESCRIPTION
### Description of your changes

Fixes #161

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

With `device` resource in provider-tf-equinix-metal and also with Unit tests.

[contribution process]: https://git.io/fj2m9
